### PR TITLE
CLI: error on a non-existent oldfile/newfile

### DIFF
--- a/cli/src/main/scala/com/typesafe/tools/mima/cli/MimaCli.scala
+++ b/cli/src/main/scala/com/typesafe/tools/mima/cli/MimaCli.scala
@@ -19,6 +19,10 @@ case class Main(
     val newBin = newBinOpt.getOrElse(
       throw new IllegalArgumentException("New binary was not specified")
     )
+    if (!oldBin.exists())
+      throw new IllegalArgumentException(s"oldfile does not exist: $oldBin")
+    if (!newBin.exists())
+      throw new IllegalArgumentException(s"newfile does not exist: $newBin")
     val problems = new MiMaLib(classpath)
       .collectProblems(oldBin, newBin, Nil)
       .flatMap(formatter.formatProblem)

--- a/cli/src/test/scala/com/typesafe/tools/mima/cli/MainSpec.scala
+++ b/cli/src/test/scala/com/typesafe/tools/mima/cli/MainSpec.scala
@@ -1,0 +1,31 @@
+package com.typesafe.tools.mima.cli
+
+import java.io.File
+import java.nio.file.Files
+
+final class MainSpec extends munit.FunSuite {
+  val existingDir = new File(".") // exists but contributes no classes (like a POM-only module)
+  val missing     = new File("does-not-exist.jar")
+
+  test("a non-existent oldfile is an error") {
+    val ex = intercept[IllegalArgumentException] {
+      Main(oldBinOpt = Some(missing), newBinOpt = Some(existingDir)).run()
+    }
+    assert(ex.getMessage.contains("oldfile does not exist"), ex.getMessage)
+  }
+
+  test("a non-existent newfile is an error") {
+    val ex = intercept[IllegalArgumentException] {
+      Main(oldBinOpt = Some(existingDir), newBinOpt = Some(missing)).run()
+    }
+    assert(ex.getMessage.contains("newfile does not exist"), ex.getMessage)
+  }
+
+  test("existing but class-less paths are not an error (POM-only-style)") {
+    val empty = Files.createTempDirectory("mima-cli-test").toFile
+    try {
+      val problems = Main(oldBinOpt = Some(empty), newBinOpt = Some(empty)).run()
+      assertEquals(problems, 0)
+    } finally empty.delete()
+  }
+}


### PR DESCRIPTION
## Problem

Passing a path that doesn't exist as the CLI's `oldfile`/`newfile` was silently absorbed by `MiMaLib`'s empty-package fallback:

- non-existent **oldfile** → no output, exit 0 (silently looks "compatible" — the file is effectively dropped)
- non-existent **newfile** → a flood of false `MissingClass` problems

```
# silent, exit 0 — bug
mima /does/not/exist.jar some-real.jar

# flood of MissingClass — bug
mima some-real.jar /does/not/exist.jar
```

## Fix

Validate in the CLI that `oldfile` and `newfile` exist, throwing `IllegalArgumentException` otherwise. `main` already catches that and prints usage, so both bad inputs now produce a clear error.

The check deliberately lives in the **CLI**, not in `MiMaLib`. The empty-package fallback in `MiMaLib.createPackage` is intentional and load-bearing: the sbt plugin relies on it for POM-only modules, whose `target/scala-*/classes` directory legitimately does not exist (see the `pom-only-project` scripted test and #768). A first attempt that added the existence check in `MiMaLib` broke exactly that case in CI — so the check belongs where a user-typed path is genuinely expected to exist.

## Verification

- `mima <missing> <real>` and `mima <real> <missing>` → clear error + usage
- `mima <real> /` (existing but class-less path) → unchanged behavior, no error
- `coreJVM/test` green; `sbtplugin/scripted sbt-mima-plugin/pom-only-project` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)