### PR TITLE
tell Scala Steward we're staying on sbt 1

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,6 @@
+updates.ignore = [
+  # staying on sbt 1, because the Scala 2 community build is stuck on sbt 1,
+  # and because we crossbuild to 2.12 anyway so it's not like the sbt 2 upgrade
+  # would get us to a 3-only or even a 2.13+-only world
+  { groupId = "org.scala-sbt", artifactId = "sbt", version = "1." }
+]


### PR DESCRIPTION
for two reasons:

* we're crossbuilt on 2.12, 2.13, and 3 so the upgrade isn't that attractive, it doesn't get Scala 2 (or even 2.12 out of the picture
* we're in the Scala 2 community build, which doesn't support sbt 2