### PR TITLE
Split released artifacts by JDK only in CI

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,8 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
   scalacOptions ++= compilerOptions(scalaVersion.value),
 )
 
-def java8or17[T](if8: => T, if17: => T): T = if (Properties.isJavaAtLeast("17")) if17 else if8
+val isJdk17inCI = Properties.isJavaAtLeast("17") && sys.env.contains("CI") // to split released artifacts by JDK
+def skipIfJdk17inCI[T](obj: => Seq[T]): Seq[T] = if (isJdk17inCI) Seq.empty else obj
 
 def compilerOptions(scalaVersion: String): Seq[String] =
   Seq(
@@ -62,7 +63,7 @@ val munit = Def.setting("org.scalameta" %%% "munit" % "1.3.3")
 
 val core = crossProject(JVMPlatform, NativePlatform).crossType(CrossType.Pure).settings(commonSettings).settings(
   name := "mima-core",
-  crossScalaVersions := java8or17(Seq(scala212, scala213, scala3_3), Nil),
+  crossScalaVersions := skipIfJdk17inCI(Seq(scala212, scala213, scala3_3)),
   libraryDependencies += munit.value % Test,
   MimaSettings.mimaSettings,
   apiMappings ++= {
@@ -82,7 +83,7 @@ val cli = crossProject(JVMPlatform)
   .settings(commonSettings)
   .settings(
     name := "mima-cli",
-    crossScalaVersions := java8or17(Seq(scala212, scala213, scala3_3), Nil),
+    crossScalaVersions := skipIfJdk17inCI(Seq(scala212, scala213, scala3_3)),
     libraryDependencies += munit.value % Test,
     mimaFailOnNoPrevious := false,
   )
@@ -90,7 +91,7 @@ val cli = crossProject(JVMPlatform)
 
 val sbtplugin = project.enablePlugins(SbtPlugin).dependsOn(core.jvm).settings(commonSettings).settings(
   name := "sbt-mima-plugin",
-  crossScalaVersions := java8or17(Seq(scala212), Seq(scala3_8)),
+  crossScalaVersions := { if (isJdk17inCI) Seq(scala3_8) else Seq(scala212) },
   (pluginCrossBuild / sbtVersion) := {
     scalaBinaryVersion.value match {
       case "2.12" => "1.5.8"
@@ -109,7 +110,7 @@ val functionalTests = Project("functional-tests", file("functional-tests"))
   .dependsOn(core.jvm)
   .settings(commonSettings)
   .settings(
-    crossScalaVersions := java8or17(Seq(scala212, scala213), Nil),
+    crossScalaVersions := skipIfJdk17inCI(Seq(scala212, scala213)),
     publish / skip := true,
     libraryDependencies += "io.get-coursier" %% "coursier" % "2.1.24",
     libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
@@ -123,7 +124,7 @@ val integrationTests = Project("integration-tests", file("integration-tests"))
   .dependsOn(functionalTests % "compile->compile")
   .settings(commonSettings)
   .settings(
-    crossScalaVersions := java8or17(Seq(scala212, scala213), Nil),
+    crossScalaVersions := skipIfJdk17inCI(Seq(scala212, scala213)),
     publish / skip := true,
     libraryDependencies += munit.value,
     Test / unmanagedSourceDirectories := Seq((functionalTests / baseDirectory).value / "src" / "it" / "scala"),


### PR DESCRIPTION
release.yml runs JDK 8 and JDK 17 in a matrix build, so artifacts it's building are split by the JDK. JDK17+ is used there to build only sbt2 plugin with scala 3.8 and nothing more.

However, on a dev machine, JDK17+ is likely to be used, given abundance of projects using it as the minimum, but that breaks the ordinary build because that forces 3.8 but, say, functional-tests needs Scala 2. sbt could not resolve it, and IntelliJ could not import it.

The split now reads the `CI` environment variable as well (which is what GA sets). That means, incidentally, that In order to build or test sbt2 plugin locally, one must set `CI`.