### PR TITLE
scalafmt: add to build

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# prep for scalafmt
+e52f43b058fc77c3337de2ca999ab87b613265d4
+# format with v3.11.5
+c987743405d9e824acbed1876ee4eaf34312d586

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,18 @@ on:
   push:
 
 jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
+      - run: sbt scalafmtCheckRepo
+
   test:
     strategy:
       fail-fast: false

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,48 @@
+version = 3.11.5
+maxColumn = 120
+
+runner {
+  dialect = scala213
+  fatalWarnings = true
+}
+
+project.layout = StandardConvention
+fileOverride {
+  "glob:**/scala-3/**" = scala3
+}
+
+newlines {
+  // keep every line break the author wrote; break only what exceeds maxColumn
+  source = keep
+  avoidForSimpleOverflow = [tooLong, punct, slc]
+}
+
+binPack.defnSite = true
+danglingParentheses.preset = false
+rewrite.trailingCommas.style = keep
+
+align {
+  allowOverflow = true
+  // on top of the default case arrows, the code aligns `=` in definitions,
+  // trailing comments and `extends`
+  tokens."+" = [
+    { code = "//" }
+    { code = "extends" }
+    { code = "=", owners = [ { regex = "Defn\\." } ] }
+  ]
+}
+
+docstrings {
+  style = keep
+  forceBlankLineBefore = false
+}
+
+// both cases occur; `{ a, b }` outnumbers `{a, b}` two to one
+spaces.inImportCurlyBraces = true
+literals.hexDigits = Unchanged
+
+// these are compiled inputs to the tests
+project.excludePaths = [
+  "glob:**/sbtplugin/src/sbt-test/**"
+  "glob:**/functional-tests/src/test/*-{ok,nok}/**"
+]

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
 )
 
 val isJdk17inCI = Properties.isJavaAtLeast("17") && sys.env.contains("CI") // to split released artifacts by JDK
+
 def skipIfJdk17inCI[T](obj: => Seq[T]): Seq[T] = if (isJdk17inCI) Seq.empty else obj
 
 def compilerOptions(scalaVersion: String): Seq[String] =
@@ -42,6 +43,7 @@ def compilerOptions(scalaVersion: String): Seq[String] =
   (CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, 12)) => Seq("-Xsource:3")
     case Some((2, 13)) => Seq("-Xsource:3-cross")
+
     case _ => Seq()
   })
 
@@ -106,6 +108,7 @@ val sbtplugin = project.enablePlugins(SbtPlugin).dependsOn(core.jvm).settings(co
 )
 
 val testFunctional = taskKey[Unit]("Run the functional test")
+
 val functionalTests = Project("functional-tests", file("functional-tests"))
   .dependsOn(core.jvm)
   .settings(commonSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -32,20 +32,20 @@ def compilerOptions(scalaVersion: String): Seq[String] =
     "-feature",
     "-Wconf:cat=deprecation&msg=Stream|JavaConverters:s",
   ) ++
-  (CrossVersion.partialVersion(scalaVersion) match {
-    case Some((2, _)) => Seq(
-      "-Xlint",
-      // these are too annoying when crossbuilding
-      "-Wconf:cat=unused-nowarn:s",
-    )
-    case _ => Seq()
-  }) ++
-  (CrossVersion.partialVersion(scalaVersion) match {
-    case Some((2, 12)) => Seq("-Xsource:3")
-    case Some((2, 13)) => Seq("-Xsource:3-cross")
+    (CrossVersion.partialVersion(scalaVersion) match {
+      case Some((2, _)) => Seq(
+          "-Xlint",
+          // these are too annoying when crossbuilding
+          "-Wconf:cat=unused-nowarn:s",
+        )
+      case _ => Seq()
+    }) ++
+    (CrossVersion.partialVersion(scalaVersion) match {
+      case Some((2, 12)) => Seq("-Xsource:3")
+      case Some((2, 13)) => Seq("-Xsource:3-cross")
 
-    case _ => Seq()
-  })
+      case _ => Seq()
+    })
 
 // Keep in sync with TestCli
 val scala212 = "2.12.21"
@@ -73,8 +73,9 @@ val core = crossProject(JVMPlatform, NativePlatform).crossType(CrossType.Pure).s
     // from https://stackoverflow.com/a/31322970/463761
     sys.props.get("sun.boot.class.path").toList
       .flatMap(_.split(java.io.File.pathSeparator))
-      .collectFirst { case str if str.endsWith(java.io.File.separator + "rt.jar") =>
-        file(str) -> url("http://docs.oracle.com/javase/8/docs/api/index.html")
+      .collectFirst {
+        case str if str.endsWith(java.io.File.separator + "rt.jar") =>
+          file(str) -> url("http://docs.oracle.com/javase/8/docs/api/index.html")
       }
       .toMap
   },

--- a/cli/src/main/scala/com/typesafe/tools/mima/cli/MimaCli.scala
+++ b/cli/src/main/scala/com/typesafe/tools/mima/cli/MimaCli.scala
@@ -76,7 +76,7 @@ object Main {
   @tailrec
   private def parseArgs(remaining: List[String], current: Main): Main =
     remaining match {
-      case Nil => current
+      case Nil                                      => current
       case ("-cp" | "--classpath") :: cpStr :: rest =>
         parseArgs(
           rest,

--- a/cli/src/main/scala/com/typesafe/tools/mima/cli/ProblemFormatter.scala
+++ b/cli/src/main/scala/com/typesafe/tools/mima/cli/ProblemFormatter.scala
@@ -45,8 +45,8 @@ case class ProblemFormatter(
       info.fullName
 
   private def bytecodeFullName(info: MemberInfo): String = {
-    val pkg = info.owner.owner.fullName.replace('.', '/')
-    val clsName = info.owner.bytecodeName
+    val pkg        = info.owner.owner.fullName.replace('.', '/')
+    val clsName    = info.owner.bytecodeName
     val memberName = info.bytecodeName match {
       case "<init>" => "\"<init>\""
       case name     => name

--- a/core/src/main/scala/com/typesafe/tools/mima/core/BufferReader.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/BufferReader.scala
@@ -1,3 +1,4 @@
+// scalafmt: { maxColumn = 140 }
 package com.typesafe.tools.mima.core
 
 import java.lang.Float.intBitsToFloat
@@ -13,8 +14,7 @@ private[core] sealed abstract class BytesReader(buf: Array[Byte]) {
   final def getChar(idx: Int): Char = (((buf(idx) & 0xff) << 8) + (buf(idx + 1) & 0xff)).toChar
 
   final def getInt(idx: Int): Int =
-    ((buf(idx    ) & 0xff) << 24) + ((buf(idx + 1) & 0xff) << 16) +
-    ((buf(idx + 2) & 0xff) << 8)  +  (buf(idx + 3) & 0xff)
+    ((buf(idx) & 0xff) << 24) + ((buf(idx + 1) & 0xff) << 16) + ((buf(idx + 2) & 0xff) << 8) + (buf(idx + 3) & 0xff)
 
   final def getLong(idx: Int): Long     = (getInt(idx).toLong << 32) + (getInt(idx + 4) & 0xffffffffL)
   final def getFloat(idx: Int): Float   = intBitsToFloat(getInt(idx))

--- a/core/src/main/scala/com/typesafe/tools/mima/core/BufferReader.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/BufferReader.scala
@@ -30,11 +30,11 @@ private[core] sealed abstract class BytesReader(buf: Array[Byte]) {
 private[core] final class BufferReader(val file: AbsFile) extends BytesReader(file.toByteArray) {
   /** the buffer pointer */
   var bp: Int = 0
-  def pos = bp
+  def pos     = bp
 
   def nextByte: Byte = { val b = getByte(bp); bp += 1; b }
   def nextChar: Char = { val c = getChar(bp); bp += 2; c } // Char = unsigned 2-bytes, aka u16
-  def nextInt: Int   = { val i = getInt(bp);  bp += 4; i }
+  def nextInt: Int   = { val i = getInt(bp); bp += 4; i }
 
   def acceptByte(exp: Byte, ctx: => String = "") = { val obt = nextByte; assert(obt == exp, s"Expected $exp, obtained $obt$ctx"); obt }
   def acceptChar(exp: Char, ctx: => String = "") = { val obt = nextChar; assert(obt == exp, s"Expected $exp, obtained $obt$ctx"); obt }
@@ -44,6 +44,7 @@ private[core] final class BufferReader(val file: AbsFile) extends BytesReader(fi
   def atIndex[T](i: Int)(body: => T): T = {
     val saved = bp
     bp = i
-    try body finally bp = saved
+    try body
+    finally bp = saved
   }
 }

--- a/core/src/main/scala/com/typesafe/tools/mima/core/ByteCodecs.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ByteCodecs.scala
@@ -19,9 +19,9 @@ package com.typesafe.tools.mima.core
 object ByteCodecs {
   /** Map 0xC0 0x80 to 0x00, then subtract 1 from each element. In-place. */
   def regenerateZero(src: Array[Byte]): Int = {
-    var i = 0
+    var i      = 0
     val srclen = src.length
-    var j = 0
+    var j      = 0
     while (i < srclen) {
       val in: Int = src(i) & 0xff
       if (in == 0xc0 && (src(i + 1) & 0xff) == 0x80) {
@@ -40,8 +40,8 @@ object ByteCodecs {
   }
 
   def decode7to8(src: Array[Byte], srclen: Int): Int = {
-    var i = 0
-    var j = 0
+    var i      = 0
+    var j      = 0
     val dstlen = (srclen * 7 + 7) / 8
     while (i + 7 < srclen) {
       var out: Int = src(i).toInt

--- a/core/src/main/scala/com/typesafe/tools/mima/core/ClassInfo.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ClassInfo.scala
@@ -1,3 +1,4 @@
+// scalafmt: { maxColumn = 150 }
 package com.typesafe.tools.mima.core
 
 import scala.reflect.NameTransformer
@@ -86,7 +87,6 @@ private[mima] sealed abstract class ClassInfo(val owner: PackageInfo) extends In
   final def isImplClass: Boolean      = bytecodeName.endsWith("$class")
   final def isInterface: Boolean      = ClassfileParser.isInterface(flags) // java interface or trait w/o impl methods
   final def isClass: Boolean          = !isTrait && !isInterface // class, object or trait's impl class
-
   final def scopedPrivateSuff: String = if (isScopedPrivate) "[..]" else ""
   final def accessModifier: String    = if (isProtected) s"protected$scopedPrivateSuff" else if (isPrivate) s"private$scopedPrivateSuff" else ""
   final def declarationPrefix: String = if (isModuleClass) "object" else if (isTrait) "trait" else if (isInterface) "interface" else "class"
@@ -101,9 +101,7 @@ private[mima] sealed abstract class ClassInfo(val owner: PackageInfo) extends In
     val idx = bytecodeName.stripSuffix("$").lastIndexOf('$')
     if (idx != -1)  {
       val outerName = bytecodeName.substring(0, idx)
-      owner.classes.getOrElse(outerName,
-        owner.classes.getOrElse(s"$outerName$$",
-          NoClass))
+      owner.classes.getOrElse(outerName, owner.classes.getOrElse(s"$outerName$$", NoClass))
     } else NoClass
   }
 

--- a/core/src/main/scala/com/typesafe/tools/mima/core/ClassInfo.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ClassInfo.scala
@@ -80,13 +80,13 @@ private[mima] sealed abstract class ClassInfo(val owner: PackageInfo) extends In
   final def annotations: List[AnnotInfo] = afterLoading(_annotations)
   final def implClass: ClassInfo         = { owner.setImplClasses; _implClass } // returns NoClass if this is not a trait
   final def moduleClass: ClassInfo       = { owner.setModules; if (_moduleClass == NoClass || _moduleClass == null) this else _moduleClass }
-  final def module: ClassInfo            = { owner.setModules; if (_module      == NoClass || _module      == null) this else _module      }
+  final def module: ClassInfo            = { owner.setModules; if (_module == NoClass || _module == null) this else _module }
 
-  final def isTrait: Boolean          = implClass ne NoClass // trait with some concrete methods or fields
-  final def isModuleClass: Boolean    = bytecodeName.endsWith("$") // super scuffed
+  final def isTrait: Boolean          = implClass ne NoClass               // trait with some concrete methods or fields
+  final def isModuleClass: Boolean    = bytecodeName.endsWith("$")         // super scuffed
   final def isImplClass: Boolean      = bytecodeName.endsWith("$class")
   final def isInterface: Boolean      = ClassfileParser.isInterface(flags) // java interface or trait w/o impl methods
-  final def isClass: Boolean          = !isTrait && !isInterface // class, object or trait's impl class
+  final def isClass: Boolean          = !isTrait && !isInterface           // class, object or trait's impl class
   final def scopedPrivateSuff: String = if (isScopedPrivate) "[..]" else ""
   final def accessModifier: String    = if (isProtected) s"protected$scopedPrivateSuff" else if (isPrivate) s"private$scopedPrivateSuff" else ""
   final def declarationPrefix: String = if (isModuleClass) "object" else if (isTrait) "trait" else if (isInterface) "interface" else "class"
@@ -99,7 +99,7 @@ private[mima] sealed abstract class ClassInfo(val owner: PackageInfo) extends In
 
   lazy val outer: ClassInfo = {
     val idx = bytecodeName.stripSuffix("$").lastIndexOf('$')
-    if (idx != -1)  {
+    if (idx != -1) {
       val outerName = bytecodeName.substring(0, idx)
       owner.classes.getOrElse(outerName, owner.classes.getOrElse(s"$outerName$$", NoClass))
     } else NoClass
@@ -118,7 +118,7 @@ private[mima] sealed abstract class ClassInfo(val owner: PackageInfo) extends In
   final def lookupClassMethods(method: MethodInfo): Iterator[MethodInfo] = {
     val name = method.bytecodeName
     if (name == MemberInfo.ConstructorName) methods.get(name) // constructors are not inherited
-    else if (method.isStatic) methods.get(name) // static methods are not inherited
+    else if (method.isStatic) methods.get(name)               // static methods are not inherited
     else thisAndSuperClasses.flatMap(_.methods.get(name))
   }
 
@@ -217,7 +217,7 @@ private[mima] sealed abstract class ClassInfo(val owner: PackageInfo) extends In
   private def hasMatchingSig(sig: String, tsig: String): Boolean = {
     val ilen = sig.length
     val tlen = tsig.length
-    var i = 2
+    var i    = 2
     while (sig(i) != ';')
       i += 1
     i += 1
@@ -229,7 +229,7 @@ private[mima] sealed abstract class ClassInfo(val owner: PackageInfo) extends In
     i == ilen && j == tlen
   }
 
-  def canEqual(other: Any) = other.isInstanceOf[ClassInfo]
+  def canEqual(other: Any)              = other.isInstanceOf[ClassInfo]
   final override def equals(other: Any) = other match {
     case that: ClassInfo => that.canEqual(this) && fullName == that.fullName
     case _               => false

--- a/core/src/main/scala/com/typesafe/tools/mima/core/ClassPath.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ClassPath.scala
@@ -16,7 +16,7 @@ private[core] final case class AbsFile(name: String)(val jpath: Path) {
 
 private[mima] sealed trait ClassPath extends Product with Serializable {
   def packages(pkg: String): Stream[String]
-  def  classes(pkg: String): Stream[AbsFile]
+  def classes(pkg: String): Stream[AbsFile]
   def asClassPathString: String
 }
 
@@ -27,7 +27,7 @@ private[mima] object ClassPath {
   def of(xs: Seq[ClassPath]): ClassPath = {
     xs.toStream.flatMap {
       case x: AggrCp => x.aggregates
-      case x                     => List(x)
+      case x         => List(x)
     } match {
       case Seq(x) => x
       case xs     => AggrCp(xs)
@@ -39,10 +39,10 @@ private[mima] object ClassPath {
     case p if file.isFile && file.getName.endsWith(".jar") => PathCp(p)(rootPath(p))
   }
 
-          def join(xs: Seq[String]) = xs.filter("" != _).mkString(java.io.File.pathSeparator)
-          def split(cp: String)     = cp.split(java.io.File.pathSeparator).toStream.filter("" != _).distinct
-  private def expandCp(cp: String)  = split(cp).flatMap(s => fromJarOrDir(new java.io.File(s)))
-  private def javaBootCp            = expandCp(System.getProperty("sun.boot.class.path", ""))
+  def join(xs: Seq[String])        = xs.filter("" != _).mkString(java.io.File.pathSeparator)
+  def split(cp: String)            = cp.split(java.io.File.pathSeparator).toStream.filter("" != _).distinct
+  private def expandCp(cp: String) = split(cp).flatMap(s => fromJarOrDir(new java.io.File(s)))
+  private def javaBootCp           = expandCp(System.getProperty("sun.boot.class.path", ""))
 
   private def list(p: Path)      = andClose(Files.newDirectoryStream(p))(_.asScala.toStream.sortBy(_.toString))
   private def listDir(p: Path)   = if (Files.isDirectory(p)) list(p) else Stream.empty
@@ -62,13 +62,14 @@ private[mima] object ClassPath {
   private def pkgContains(pkg: String, sub: String) =
     pkg.isEmpty || sub.startsWith(pkg) && sub.lastIndexOf(".") == pkg.length
 
-  private def jrt = if (!scala.util.Properties.isJavaAtLeast("9")) of(Nil) else
+  private def jrt = if (!scala.util.Properties.isJavaAtLeast("9")) of(Nil)
+  else
     try JrtCp(FileSystems.getFileSystem(java.net.URI.create("jrt:/")))
     catch { case _: ProviderNotFoundException | _: FileSystemNotFoundException => of(Nil) }
 
   private final case class JrtCp(fs: FileSystem) extends ClassPath {
     def packages(pkg: String) = packageToModules.keys.toStream.filter(pkgContains(pkg, _)).sorted
-    def  classes(pkg: String) = packageToModules(pkg).flatMap(pkgClasses(_, pkg)).sortBy(_.toString).map(new AbsFile(_))
+    def classes(pkg: String)  = packageToModules(pkg).flatMap(pkgClasses(_, pkg)).sortBy(_.toString).map(new AbsFile(_))
     def asClassPathString     = fs.toString
 
     private val packageToModules = listDir(fs.getPath("/packages"))
@@ -78,16 +79,17 @@ private[mima] object ClassPath {
 
   private final case class PathCp(src: Path)(root: Path) extends ClassPath {
     def packages(pkg: String) = listDir(pkgResolve(root, pkg)).filter(isPackage).map(pkgEntry(pkg, _))
-    def  classes(pkg: String) = listDir(pkgResolve(root, pkg)).filter(isClass).map(new AbsFile(_))
+    def classes(pkg: String)  = listDir(pkgResolve(root, pkg)).filter(isClass).map(new AbsFile(_))
     def asClassPathString     = src.toString
   }
 
   private final case class AggrCp(aggregates: Stream[ClassPath]) extends ClassPath {
     def packages(pkg: String) = aggregates.flatMap(_.packages(pkg)).distinct
-    def  classes(pkg: String) = aggregates.flatMap(_.classes(pkg)).distinct
+    def classes(pkg: String)  = aggregates.flatMap(_.classes(pkg)).distinct
     def asClassPathString     = join(aggregates.map(_.asClassPathString).distinct)
   }
 
   private def andClose[A <: AutoCloseable, B](xs: A)(f: A => B): B =
-    try f(xs) finally xs.close()
+    try f(xs)
+    finally xs.close()
 }

--- a/core/src/main/scala/com/typesafe/tools/mima/core/ClassPath.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ClassPath.scala
@@ -88,5 +88,6 @@ private[mima] object ClassPath {
     def asClassPathString     = join(aggregates.map(_.asClassPathString).distinct)
   }
 
-  private def andClose[A <: AutoCloseable, B](xs: A)(f: A => B): B = try f(xs) finally xs.close()
+  private def andClose[A <: AutoCloseable, B](xs: A)(f: A => B): B =
+    try f(xs) finally xs.close()
 }

--- a/core/src/main/scala/com/typesafe/tools/mima/core/ClassfileConstants.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ClassfileConstants.scala
@@ -1,3 +1,5 @@
+// scalafmt cannot reproduce the hand-aligned columns below
+// format: off
 package com.typesafe.tools.mima.core
 
 private[core] object ClassfileConstants {

--- a/core/src/main/scala/com/typesafe/tools/mima/core/ClassfileParser.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ClassfileParser.scala
@@ -124,7 +124,7 @@ final class ClassfileParser private (in: BufferReader, pool: ConstantPool) {
       case STRING_TAG |  CLASS_TAG => in.skip(2)
       case                ENUM_TAG => in.skip(4)
       case               ARRAY_TAG => for (_ <- 0 until in.nextChar) skipAnnotArg()
-      case          ANNOTATION_TAG => in.skip(2); /* type */ skipAnnotArgs()
+      case ANNOTATION_TAG         => in.skip(2) /* type */; skipAnnotArgs()
     }
 
     def skipAnnotArgs() = for (_ <- 0 until in.nextChar) { in.skip(2); skipAnnotArg() }

--- a/core/src/main/scala/com/typesafe/tools/mima/core/ClassfileParser.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ClassfileParser.scala
@@ -15,8 +15,8 @@ final class ClassfileParser private (in: BufferReader, pool: ConstantPool) {
 
     clazz._superClass = parseSuperClass(clazz, flags)
     clazz._interfaces = parseInterfaces()
-    clazz._fields     = parseMembers[FieldInfo](clazz)
-    clazz._methods    = parseMembers[MethodInfo](clazz)
+    clazz._fields = parseMembers[FieldInfo](clazz)
+    clazz._methods = parseMembers[MethodInfo](clazz)
     parseClassAttributes(clazz)
   }
 
@@ -31,7 +31,7 @@ final class ClassfileParser private (in: BufferReader, pool: ConstantPool) {
     List.fill(in.nextChar)(pool.getSuperClass(in.nextChar))
   }
 
-  private def parseMembers[A <: MemberInfo : MkMember](clazz: ClassInfo): Members[A] = {
+  private def parseMembers[A <: MemberInfo: MkMember](clazz: ClassInfo): Members[A] = {
     val members = for {
       _ <- 0.until(in.nextChar).iterator
       flags = in.nextChar
@@ -41,7 +41,7 @@ final class ClassfileParser private (in: BufferReader, pool: ConstantPool) {
     new Members(members.toList)
   }
 
-  private def parseMember[A <: MemberInfo : MkMember](clazz: ClassInfo, flags: Int): A = {
+  private def parseMember[A <: MemberInfo: MkMember](clazz: ClassInfo, flags: Int): A = {
     val name       = pool.getName(in.nextChar)
     val descriptor = pool.getExternalName(in.nextChar)
     val member     = implicitly[MkMember[A]].make(clazz, name, flags, descriptor)
@@ -50,11 +50,11 @@ final class ClassfileParser private (in: BufferReader, pool: ConstantPool) {
   }
 
   private def parseClassAttributes(clazz: ClassInfo) = {
-    var isScala = false
+    var isScala           = false
     var runtimeAnnotStart = -1
     parseAttributes {
       case RuntimeAnnotationATTR => runtimeAnnotStart = in.bp
-      case ScalaSignatureATTR    => isScala    = true
+      case ScalaSignatureATTR    => isScala = true
       case EnclosingMethodATTR   => clazz._isLocalClass = true
       case InnerClassesATTR      => clazz._innerClasses = parseInnerClasses(clazz)
       case TASTYATTR             => parseTasty(clazz)
@@ -96,7 +96,7 @@ final class ClassfileParser private (in: BufferReader, pool: ConstantPool) {
   }
 
   private def parsePickle(clazz: ClassInfo) = {
-    def parseScalaSigBytes()     = {
+    def parseScalaSigBytes() = {
       in.acceptByte(STRING_TAG, s" for ${clazz.description}")
       pool.getBytes(in.nextChar)
     }
@@ -117,21 +117,21 @@ final class ClassfileParser private (in: BufferReader, pool: ConstantPool) {
     }
 
     def skipAnnotArg(): Unit = in.nextByte match {
-      case   BOOL_TAG |   BYTE_TAG => in.skip(2)
-      case   CHAR_TAG |  SHORT_TAG => in.skip(2)
-      case    INT_TAG |   LONG_TAG => in.skip(2)
-      case  FLOAT_TAG | DOUBLE_TAG => in.skip(2)
-      case STRING_TAG |  CLASS_TAG => in.skip(2)
-      case                ENUM_TAG => in.skip(4)
-      case               ARRAY_TAG => for (_ <- 0 until in.nextChar) skipAnnotArg()
+      case BOOL_TAG | BYTE_TAG    => in.skip(2)
+      case CHAR_TAG | SHORT_TAG   => in.skip(2)
+      case INT_TAG | LONG_TAG     => in.skip(2)
+      case FLOAT_TAG | DOUBLE_TAG => in.skip(2)
+      case STRING_TAG | CLASS_TAG => in.skip(2)
+      case ENUM_TAG               => in.skip(4)
+      case ARRAY_TAG              => for (_ <- 0 until in.nextChar) skipAnnotArg()
       case ANNOTATION_TAG         => in.skip(2) /* type */; skipAnnotArgs()
     }
 
     def skipAnnotArgs() = for (_ <- 0 until in.nextChar) { in.skip(2); skipAnnotArg() }
 
     val numAnnots = in.nextChar
-    var i = 0
-    var bytes = new Array[Byte](0)
+    var i         = 0
+    var bytes     = new Array[Byte](0)
     while (i < numAnnots && bytes.length == 0) {
       pool.getExternalName(in.nextChar) match {
         case ScalaSignatureAnnot     => checkScalaSigAnnotArg(); bytes = parseScalaSigBytes()
@@ -166,7 +166,7 @@ object ClassfileParser {
   private[core] def parseInPlace(clazz: ClassInfo, file: AbsFile): Unit = {
     val in = new BufferReader(file)
     parseHeader(in, file)
-    val pool = ConstantPool.parseNew(clazz.owner.definitions, in)
+    val pool   = ConstantPool.parseNew(clazz.owner.definitions, in)
     val parser = new ClassfileParser(in, pool)
     parser.parseClass(clazz)
   }
@@ -187,7 +187,7 @@ object ClassfileParser {
     if (magic != JAVA_MAGIC)
       throw new IOException(
         s"class file '$file' has wrong magic number 0x${magic.toHexString}, " +
-            s"should be 0x${JAVA_MAGIC.toHexString}")
+          s"should be 0x${JAVA_MAGIC.toHexString}")
     in.skip(2) // minorVersion
     in.skip(2) // majorVersion
   }

--- a/core/src/main/scala/com/typesafe/tools/mima/core/ConstantPool.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ConstantPool.scala
@@ -7,7 +7,7 @@ import ClassfileConstants._
 private[core] object ConstantPool {
   def parseNew(definitions: Definitions, in: BufferReader): ConstantPool = {
     val starts = new Array[Int](in.nextChar)
-    var i = 1
+    var i      = 1
     while (i < starts.length) {
       starts(i) = in.bp
       i += 1
@@ -36,8 +36,7 @@ private[core] object ConstantPool {
   private def abort(msg: String): Nothing = throw new RuntimeException(msg)
 }
 
-private[core]
-final class ConstantPool private (definitions: Definitions, in: BytesReader, starts: Array[Int]) {
+private[core] final class ConstantPool private (definitions: Definitions, in: BytesReader, starts: Array[Int]) {
   import ConstantPool._, ClassInfo.ObjectClass
 
   def file: AbsFile = in.file
@@ -112,7 +111,7 @@ final class ConstantPool private (definitions: Definitions, in: BytesReader, sta
 
   private def firstExpecting(index: Int, expectedTag: Int) = {
     val start = starts(index)
-    val tag = in.getByte(start).toInt
+    val tag   = in.getByte(start).toInt
     if (tag == expectedTag) start + 1
     else errorBadTag(tag, start)
   }

--- a/core/src/main/scala/com/typesafe/tools/mima/core/Definitions.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/Definitions.scala
@@ -54,7 +54,7 @@ private[mima] final class Definitions(val classPath: ClassPath) {
     }
 
     def newClassType: ClassType = {
-      val end = descriptor.indexOf(';', in)
+      val end      = descriptor.indexOf(';', in)
       val fullName = descriptor.substring(in, end).replace('/', '.')
       in = end + 1
       ClassType(fromName(fullName))

--- a/core/src/main/scala/com/typesafe/tools/mima/core/InfoLike.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/InfoLike.scala
@@ -10,7 +10,6 @@ private[core] abstract class InfoLike {
 
   /** The name as found in the original Scala source. */
   final def decodedName: String  = NameTransformer.decode(bytecodeName)
-
   final def isPublic: Boolean    = ClassfileParser.isPublic(flags)
   final def isPrivate: Boolean   = ClassfileParser.isPrivate(flags)
   final def isProtected: Boolean = ClassfileParser.isProtected(flags)
@@ -19,7 +18,6 @@ private[core] abstract class InfoLike {
   final def isBridge: Boolean    = ClassfileParser.isBridge(flags)
   final def isDeferred: Boolean  = ClassfileParser.isDeferred(flags)
   final def isSynthetic: Boolean = ClassfileParser.isSynthetic(flags)
-
   final def nonPublic: Boolean   = !isPublic
   final def nonFinal: Boolean    = !isFinal
   final def isConcrete: Boolean  = !isDeferred

--- a/core/src/main/scala/com/typesafe/tools/mima/core/MemberInfo.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/MemberInfo.scala
@@ -45,6 +45,7 @@ private[mima] final class MethodInfo(owner: ClassInfo, bytecodeName: String, fla
   def methodString: String      = s"$shortMethodString in ${owner.classString}"
   def shortMethodString: String = {
     val prefix = if (hasSyntheticName) if (isExtensionMethod) "extension " else "synthetic " else ""
+
     val deprecated = if (isDeprecated) "deprecated " else ""
 
     val privatePrefix = if (isScopedPrivate) {
@@ -61,6 +62,7 @@ private[mima] final class MethodInfo(owner: ClassInfo, bytecodeName: String, fla
   lazy val paramsCount: Int = {
     tpe match {
       case MethodType(paramTypes, _) => paramTypes.length
+
       case _ => throw new MatchError(s"Failed to get method params, member had type $tpe, not MethodType.")
     }
   }

--- a/core/src/main/scala/com/typesafe/tools/mima/core/MemberInfo.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/MemberInfo.scala
@@ -5,12 +5,11 @@ object MemberInfo {
 }
 
 sealed abstract class MemberInfo(val owner: ClassInfo, val bytecodeName: String, val flags: Int, val descriptor: String)
-    extends InfoLike
-{
+    extends InfoLike {
   final var isDeprecated: Boolean  = false
   final var signature: Signature   = Signature.none // Includes generics. 'descriptor' is the erased version.
   final var scopedPrivate: Boolean = false
-  final var classPrivate: Boolean = false
+  final var classPrivate: Boolean  = false
 
   def nonAccessible: Boolean
 
@@ -29,16 +28,14 @@ sealed abstract class MemberInfo(val owner: ClassInfo, val bytecodeName: String,
 }
 
 private[mima] final class FieldInfo(owner: ClassInfo, bytecodeName: String, flags: Int, descriptor: String)
-    extends MemberInfo(owner, bytecodeName, flags, descriptor)
-{
+    extends MemberInfo(owner, bytecodeName, flags, descriptor) {
   def nonAccessible: Boolean = !isPublic || isSynthetic || hasSyntheticName
   def fieldString: String    = s"${staticPrefix}field $decodedName in ${owner.classString}"
   override def toString      = s"field $bytecodeName: $descriptor"
 }
 
 private[mima] final class MethodInfo(owner: ClassInfo, bytecodeName: String, flags: Int, descriptor: String)
-    extends MemberInfo(owner, bytecodeName, flags, descriptor)
-{
+    extends MemberInfo(owner, bytecodeName, flags, descriptor) {
   final var _annotations: List[AnnotInfo] = Nil
   final def annotations: List[AnnotInfo]  = _annotations
 
@@ -81,7 +78,7 @@ private[mima] final class MethodInfo(owner: ClassInfo, bytecodeName: String, fla
   }
   def nonAccessible: Boolean = {
     !isPublic || isScopedPrivate || isClassPrivate || isSynthetic ||
-      (hasSyntheticName && !(isExtensionMethod || isDefaultGetter || isTraitInit))
+    (hasSyntheticName && !(isExtensionMethod || isDefaultGetter || isTraitInit))
   }
   def isScopedPrivate: Boolean = scopedPrivate
 

--- a/core/src/main/scala/com/typesafe/tools/mima/core/MimaUnpickler.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/MimaUnpickler.scala
@@ -8,7 +8,7 @@ object MimaUnpickler {
     if (buf.bytes.length == 0) return
 
     val doPrint = false
-    //val doPrint = path.contains("v1") && !path.contains("exclude.class")
+    // val doPrint = path.contains("v1") && !path.contains("exclude.class")
     if (doPrint) {
       println(s"unpickling $path")
       PicklePrinter.printPickle(buf)
@@ -19,7 +19,7 @@ object MimaUnpickler {
     val index    = buf.createIndex
     val entries  = new Array[Entry](index.length)
     val classes  = new scala.collection.mutable.HashMap[SymInfo, ClassInfo]
-    def     syms = entries.iterator.collect { case s: SymbolInfo => s }
+    def syms     = entries.iterator.collect { case s: SymbolInfo => s }
     def defnSyms = syms.filter(sym => sym.tag == CLASSsym || sym.tag == MODULEsym)
     def methSyms = syms.filter(sym => sym.tag == VALsym)
 
@@ -60,13 +60,13 @@ object MimaUnpickler {
     }
 
     def readSym(tag: Int): SymInfo = tag match {
-      case   NONEsym      => readSymbol(tag)
-      case   TYPEsym      => readSymbol(tag)
-      case  ALIASsym      => readSymbol(tag)
-      case  CLASSsym      => readSymbol(tag) // CLASSsym len_Nat SymbolInfo [thistype_Ref]
+      case NONEsym        => readSymbol(tag)
+      case TYPEsym        => readSymbol(tag)
+      case ALIASsym       => readSymbol(tag)
+      case CLASSsym       => readSymbol(tag) // CLASSsym len_Nat SymbolInfo [thistype_Ref]
       case MODULEsym      => readSymbol(tag)
-      case    VALsym      => readSymbol(tag)
-      case         EXTref => readExt(tag)
+      case VALsym         => readSymbol(tag)
+      case EXTref         => readExt(tag)
       case EXTMODCLASSref => readExt(tag)
       case tag            => sys.error(s"Unexpected tag ${tag2string(tag)}")
     }
@@ -108,7 +108,7 @@ object MimaUnpickler {
       val tag = buf.readByte()
       val end = readEnd()
       tag match {
-        case    THIStpe => ThisTypeInfo(readSymRef())
+        case THIStpe    => ThisTypeInfo(readSymRef())
         case TYPEREFtpe => TypeRefInfo(readTypeRef(), readSymRef(), until(end, () => readTypeRef()))
         case _          => UnknownType(tag)
       }
@@ -127,12 +127,12 @@ object MimaUnpickler {
     def readEntry() = {
       val tag = buf.readByte()
       tag match {
-        case   NONEsym => readSymbol(tag)
-        case   TYPEsym => readSymbol(tag)
-        case  ALIASsym => readSymbol(tag)
-        case  CLASSsym => readSymbol(tag)
+        case NONEsym   => readSymbol(tag)
+        case TYPEsym   => readSymbol(tag)
+        case ALIASsym  => readSymbol(tag)
+        case CLASSsym  => readSymbol(tag)
         case MODULEsym => readSymbol(tag)
-        case    VALsym => readSymbol(tag)
+        case VALsym    => readSymbol(tag)
         case SYMANNOT  => readSymbolAnnotation()
         case _         => buf.readIndex = readEnd(); UnknownEntry(tag)
       }
@@ -284,10 +284,10 @@ object MimaUnpickler {
     var idx = 0
     var res = 0L
     var b   = 0L
-    while({
-      b    = data(idx).toLong
+    while ({
+      b = data(idx).toLong
       idx += 1
-      res  = (res << 7) + (b & 0x7f)
+      res = (res << 7) + (b & 0x7f)
       (b & 0x80) != 0L
     }) ()
     res.toInt

--- a/core/src/main/scala/com/typesafe/tools/mima/core/MimaUnpickler.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/MimaUnpickler.scala
@@ -1,3 +1,4 @@
+// scalafmt: { maxColumn = 160 }
 package com.typesafe.tools.mima.core
 
 import com.typesafe.tools.mima.core.PickleFormat.*
@@ -80,6 +81,7 @@ object MimaUnpickler {
       val name  = readNameRef()
       val owner = readSymRef()
       val flags = buf.readLongNat()
+
       val (privateWithin, info) = buf.readNat() match {
         case info if buf.readIndex == end => (-1, info)
         case privateWithin                => (privateWithin, buf.readNat())
@@ -154,6 +156,7 @@ object MimaUnpickler {
         NoClass
       } else {
         val fallback = if (symbolInfo.isModuleOrModuleClass) clazz.moduleClass else clazz
+
         def lookup(cls: ClassInfo) = {
           val clsName   = cls.bytecodeName
           val separator = if (clsName.endsWith("$")) "" else "$"
@@ -235,6 +238,7 @@ object MimaUnpickler {
   final case class UnknownEntry(tag: Int) extends Entry
 
   sealed trait Name extends Entry { def tag: Int; def value: String }
+
   final case class TermName(value: String) extends Name { def tag = TERMname }
   final case class TypeName(value: String) extends Name { def tag = TYPEname }
 
@@ -269,11 +273,11 @@ object MimaUnpickler {
   final case class ExtInfo(tag: Int, name: Name, owner: SymInfo) extends SymInfo
 
   sealed trait TypeInfo extends Entry
+
   final case class UnknownType(tag: Int) extends TypeInfo
 
   final case class ThisTypeInfo(sym: SymInfo)                                      extends TypeInfo
   final case class TypeRefInfo(tpe: TypeInfo, sym: SymInfo, targs: List[TypeInfo]) extends TypeInfo
-
   final case class SymAnnotInfo(sym: SymbolInfo, tpe: TypeInfo)                    extends Entry
 
   def readNat(data: Array[Byte]): Int = {

--- a/core/src/main/scala/com/typesafe/tools/mima/core/PackageInfo.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/PackageInfo.scala
@@ -1,6 +1,6 @@
 package com.typesafe.tools.mima.core
 
-import scala.annotation.{nowarn, tailrec}
+import scala.annotation.{ nowarn, tailrec }
 import scala.collection.mutable
 
 sealed class SyntheticPackageInfo(val owner: PackageInfo, val name: String) extends PackageInfo {
@@ -9,18 +9,17 @@ sealed class SyntheticPackageInfo(val owner: PackageInfo, val name: String) exte
   lazy val classes  = Map.empty[String, ClassInfo]
 }
 
-@nowarn("msg=under -Xsource:3, inferred")  // return types are a bit different between 2 and 3 but it's fine afaics
+@nowarn("msg=under -Xsource:3, inferred") // return types are a bit different between 2 and 3 but it's fine afaics
 object NoPackageInfo extends PackageInfo {
   val name        = "<no package>"
-  val owner        = this
+  val owner       = this
   def definitions = sys.error("Called definitions on NoPackageInfo")
   val packages    = mutable.Map.empty[String, PackageInfo]
   val classes     = Map.empty[String, ClassInfo]
 }
 
 sealed class ConcretePackageInfo(val owner: PackageInfo, cp: ClassPath, pkg: String, defs: Definitions)
-    extends PackageInfo
-{
+    extends PackageInfo {
   def name        = pkg.split('.').last
   def definitions = defs
 
@@ -43,8 +42,7 @@ final private[core] class DefinitionsPackageInfo(defs: Definitions)
     extends ConcretePackageInfo(NoPackageInfo, defs.classPath, ClassPath.RootPackage, defs)
 
 final private[mima] class DefinitionsTargetPackageInfo(root: PackageInfo)
-    extends SyntheticPackageInfo(root, "<root>")
-{
+    extends SyntheticPackageInfo(root, "<root>") {
   // Needed to fetch classes located in the root (empty package).
   override lazy val classes = root.classes
 }
@@ -107,7 +105,7 @@ sealed abstract class PackageInfo {
       if clazz.isModuleClass
       module <- classes.get(name.init)
     } {
-      clazz._module       = module
+      clazz._module = module
       module._moduleClass = clazz
     }
   }

--- a/core/src/main/scala/com/typesafe/tools/mima/core/PickleBuffer.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/PickleBuffer.scala
@@ -12,7 +12,7 @@ final class PickleBuffer(val bytes: Array[Byte]) {
   def readLongNat(): Long = {
     var b = 0L
     var x = 0L
-    while({
+    while ({
       b = readByte().toLong
       x = (x << 7) + (b & 0x7f)
       (b & 0x80) != 0L
@@ -50,7 +50,8 @@ final class PickleBuffer(val bytes: Array[Byte]) {
   def atIndex[T](i: Int)(body: => T): T = {
     val saved = readIndex
     readIndex = i
-    try body finally readIndex = saved
+    try body
+    finally readIndex = saved
   }
 
   def assertEnd(end: Int) = assert(readIndex == end, s"Expected at end=$end but readIndex=$readIndex")

--- a/core/src/main/scala/com/typesafe/tools/mima/core/PickleFormat.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/PickleFormat.scala
@@ -1,3 +1,5 @@
+// scalafmt cannot reproduce the hand-aligned columns below
+// format: off
 package com.typesafe.tools.mima.core
 
 object PickleFormat {

--- a/core/src/main/scala/com/typesafe/tools/mima/core/PicklePrinter.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/PicklePrinter.scala
@@ -1,3 +1,5 @@
+// scalafmt cannot reproduce the hand-aligned columns below
+// format: off
 package com.typesafe.tools.mima.core
 
 import java.lang.Long.toHexString

--- a/core/src/main/scala/com/typesafe/tools/mima/core/ProblemReporting.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ProblemReporting.scala
@@ -6,10 +6,12 @@ private[mima] object ProblemReporting {
   val versionOrdering: Ordering[String] = {
     // version string "x.y.z" is converted to a Long tuple (x, y, z) for comparison
     val VersionRegex = """(\d+)\.?(\d+)?\.?(.*)?""".r
+
     def long(versionPart: String) =
       Try(versionPart.replace("x", Long.MaxValue.toString).filter(_.isDigit).toLong).getOrElse(0L)
     Ordering[(Long, Long, Long)].on[String] {
       case VersionRegex(x, y, z) => (long(x), long(y), long(z))
+
       case bad => throw new IllegalArgumentException(bad)
     }
   }

--- a/core/src/main/scala/com/typesafe/tools/mima/core/Problems.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/Problems.scala
@@ -1,3 +1,4 @@
+// scalafmt: { maxColumn = 280 }
 package com.typesafe.tools.mima.core
 
 trait ProblemRef {
@@ -20,7 +21,9 @@ sealed abstract class Problem extends ProblemRef {
   }
 
   /** 'affectedVersion' is "current" for bincompat, "other" or "previous" for forward-compat. */
-  final def description: String => String = affectedVersion => this match {
+  final def description: String => String = getDescription(_)
+
+  private def getDescription(affectedVersion: String): String = this match {
     case MissingClassProblem(oldclazz)                 => s"${oldclazz.classString} does not have a correspondent in $affectedVersion version"
     case IncompatibleTemplateDefProblem(ref, newclazz) => s"declaration of ${ref.description} is ${newclazz.description} in $affectedVersion version; changing ${ref.declarationPrefix} to ${newclazz.declarationPrefix} breaks client code"
     case InaccessibleClassProblem(ref)                 => s"${ref.classString} is inaccessible in $affectedVersion version, it must be public."

--- a/core/src/main/scala/com/typesafe/tools/mima/core/Problems.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/Problems.scala
@@ -64,16 +64,16 @@ final case class CyclicTypeReferenceProblem(clazz: ClassInfo)                   
 final case class MissingTypesProblem(newclazz: ClassInfo, missing: Iterable[ClassInfo])   extends TemplateProblem(newclazz)
 
 // Member problems
-sealed abstract class MemberProblem(val ref: MemberInfo)                                      extends Problem with MemberRef
+sealed abstract class MemberProblem(val ref: MemberInfo) extends Problem with MemberRef
 
 /// Field problems
-final case class MissingFieldProblem(oldfld: FieldInfo)                                       extends MemberProblem(oldfld)
-final case class InaccessibleFieldProblem(newfld: FieldInfo)                                  extends MemberProblem(newfld)
-final case class IncompatibleFieldTypeProblem(oldfld: FieldInfo, newfld: FieldInfo)           extends MemberProblem(oldfld)
+final case class MissingFieldProblem(oldfld: FieldInfo)                             extends MemberProblem(oldfld)
+final case class InaccessibleFieldProblem(newfld: FieldInfo)                        extends MemberProblem(newfld)
+final case class IncompatibleFieldTypeProblem(oldfld: FieldInfo, newfld: FieldInfo) extends MemberProblem(oldfld)
 
 /// Member-generic problems
-final case class StaticVirtualMemberProblem(oldmemb: MemberInfo)                              extends AbstractMethodProblem(oldmemb)
-final case class VirtualStaticMemberProblem(oldmemb: MemberInfo)                              extends AbstractMethodProblem(oldmemb)
+final case class StaticVirtualMemberProblem(oldmemb: MemberInfo) extends AbstractMethodProblem(oldmemb)
+final case class VirtualStaticMemberProblem(oldmemb: MemberInfo) extends AbstractMethodProblem(oldmemb)
 
 /// Method problems
 sealed abstract class MissingMethodProblem(meth: MethodInfo)                                  extends MemberProblem(meth)

--- a/core/src/main/scala/com/typesafe/tools/mima/core/Signature.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/Signature.scala
@@ -17,7 +17,8 @@ class Signature(private val signature: String) {
           sig
             .replace(s"<${from}:", s"<__${to}__:")
             .replace(s";${from}:", s";__${to}__:")
-            .replace(s"T${from};", s"__${to}__") }
+            .replace(s"T${from};", s"__${to}__")
+        }
     }
   }
 
@@ -38,8 +39,8 @@ class Signature(private val signature: String) {
 
   // Special case for scala#7975
   private def hasMatchingCtorSig(newer: String): Boolean =
-    newer.isEmpty || // ignore losing signature on constructors
-    signature.endsWith(newer.tail) // ignore losing the 1st (outer) param (.tail drops the leading '(')
+    newer.isEmpty ||                 // ignore losing signature on constructors
+      signature.endsWith(newer.tail) // ignore losing the 1st (outer) param (.tail drops the leading '(')
 
   // a method that takes no parameters and returns Object can have no signature
   override def toString = if (signature.isEmpty) "<missing>" else signature
@@ -64,8 +65,8 @@ object Signature {
     }
 
     def parseOne(in: String): (FormalTypeParameter, String) = {
-      val identifier = in.takeWhile(_ != ':')
-      val boundAndRest = in.dropWhile(_ != ':').drop(1)
+      val identifier    = in.takeWhile(_ != ':')
+      val boundAndRest  = in.dropWhile(_ != ':').drop(1)
       val (bound, rest) = splitBoundAndRest(boundAndRest)
       (FormalTypeParameter(identifier, bound), rest)
     }

--- a/core/src/main/scala/com/typesafe/tools/mima/core/Signature.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/Signature.scala
@@ -8,8 +8,10 @@ class Signature(private val signature: String) {
   lazy val canonicalized = {
     signature.headOption match {
       case None | Some('(') => signature
+
       case _ =>
         val (formalTypeParameters, _) = FormalTypeParameter.parseList(signature.drop(1))
+
         val replacements = formalTypeParameters.map(_.identifier).zipWithIndex
         replacements.foldLeft(signature) { case (sig, (from, to)) =>
           sig
@@ -33,7 +35,7 @@ class Signature(private val signature: String) {
     // Also match when the signature only differs in the name of a type parameter
     canonicalized == newer.canonicalized
   }
- 
+
   // Special case for scala#7975
   private def hasMatchingCtorSig(newer: String): Boolean =
     newer.isEmpty || // ignore losing signature on constructors

--- a/core/src/main/scala/com/typesafe/tools/mima/core/TastyFormat.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/TastyFormat.scala
@@ -1,3 +1,5 @@
+// scalafmt cannot reproduce the hand-aligned columns below
+// format: off
 package com.typesafe.tools.mima.core
 
 /** BNF notation.

--- a/core/src/main/scala/com/typesafe/tools/mima/core/TastyPrinter.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/TastyPrinter.scala
@@ -1,3 +1,4 @@
+// scalafmt: { maxColumn = 160 }
 package com.typesafe.tools.mima.core
 
 import TastyFormat._, TastyTagOps._
@@ -67,23 +68,16 @@ object TastyPrinter {
           case TYPEDEF        => printName(); printTrees()
           case TYPEPARAM      => printName(); printTrees()
           case     PARAM      => printName(); printTrees()
-
           case RETURN         => printNat(); printTrees()
-
           case BIND           => printName(); printTrees()
           case REFINEDtype    => printName(); printTrees()
-
           case       POLYtype => printMethodic()
           case TYPELAMBDAtype => printMethodic()
-
           case      PARAMtype => printNat(); printNat() // target/ref Addr + paramNum
-
           case TERMREFin      => printName(); printTrees()
           case TYPEREFin      => printName(); printTrees()
           case  SELECTin      => printName(); printTrees()
-
           case     METHODtype => printMethodic()
-
           case _              => printTrees()
         }
         if (currentAddr != end) {
@@ -127,6 +121,7 @@ object TastyPrinter {
   private def unpicklePkgAndClsName(in: TastyReader, names: Names): (Name, Name) = {
     import in._
     def readName(r: TastyReader = in) = names(r.readNat())
+
     def readNames(packageName: Name): (Name, Name) = readByte() match {
       case TYPEDEF    => readEnd(); (packageName, readName())
       case PACKAGE    => readEnd(); readNames(packageName)

--- a/core/src/main/scala/com/typesafe/tools/mima/core/TastyPrinter.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/TastyPrinter.scala
@@ -8,12 +8,12 @@ object TastyPrinter {
   def printPickle(in: TastyReader, path: String): Unit = {
     println(s"unpickling $path")
 
-    //val header =
-      readHeader(in)
-    //printHeader(header)
+    // val header =
+    readHeader(in)
+    // printHeader(header)
 
     val names = readNames(in)
-    //printNames(names)
+    // printNames(names)
 
     printAllTrees(getTreeReader(in, names), names)
   }
@@ -49,9 +49,9 @@ object TastyPrinter {
       print(s" ${astTagToString(tag)}")
 
       def printLengthTree() = {
-        val len = readNat()
-        val end = currentAddr + len
-        def printTrees() = doUntil(end)(printTree())
+        val len             = readNat()
+        val end             = currentAddr + len
+        def printTrees()    = doUntil(end)(printTree())
         def printMethodic() = {
           printTree()
           while (currentAddr.index < end.index && !isModifierTag(nextByte)) {
@@ -63,21 +63,21 @@ object TastyPrinter {
 
         print(s"(${lengthStr(len.toString)})")
         tag match {
-          case  VALDEF        => printName(); printTrees()
-          case  DEFDEF        => printName(); printTrees()
+          case VALDEF         => printName(); printTrees()
+          case DEFDEF         => printName(); printTrees()
           case TYPEDEF        => printName(); printTrees()
           case TYPEPARAM      => printName(); printTrees()
-          case     PARAM      => printName(); printTrees()
+          case PARAM          => printName(); printTrees()
           case RETURN         => printNat(); printTrees()
           case BIND           => printName(); printTrees()
           case REFINEDtype    => printName(); printTrees()
-          case       POLYtype => printMethodic()
+          case POLYtype       => printMethodic()
           case TYPELAMBDAtype => printMethodic()
-          case      PARAMtype => printNat(); printNat() // target/ref Addr + paramNum
+          case PARAMtype      => printNat(); printNat() // target/ref Addr + paramNum
           case TERMREFin      => printName(); printTrees()
           case TYPEREFin      => printName(); printTrees()
-          case  SELECTin      => printName(); printTrees()
-          case     METHODtype => printMethodic()
+          case SELECTin       => printName(); printTrees()
+          case METHODtype     => printMethodic()
           case _              => printTrees()
         }
         if (currentAddr != end) {
@@ -87,7 +87,7 @@ object TastyPrinter {
       }
 
       def printNatASTTree() = tag match {
-        case TERMREFsymbol | TYPEREFsymbol => printNat();  printTree()
+        case TERMREFsymbol | TYPEREFsymbol => printNat(); printTree()
         case _                             => printName(); printTree()
       }
 
@@ -134,6 +134,6 @@ object TastyPrinter {
   }
 
   private def nameStr(str: String)   = Console.MAGENTA + str + Console.RESET
-  private def treeStr(str: String)   = Console.YELLOW  + str + Console.RESET
-  private def lengthStr(str: String) = Console.CYAN    + str + Console.RESET
+  private def treeStr(str: String)   = Console.YELLOW + str + Console.RESET
+  private def lengthStr(str: String) = Console.CYAN + str + Console.RESET
 }

--- a/core/src/main/scala/com/typesafe/tools/mima/core/TastyReader.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/TastyReader.scala
@@ -25,7 +25,7 @@ final class TastyReader(val bytes: Array[Byte], start: Int, end: Int, val base: 
   def readEnd(): Addr        = addr(readNat() + bp) // Read a length number and return the absolute end address implied by it, given as (address following length field) + (length-value-read)
   def goto(addr: Addr): Unit = bp = index(addr)     // Set read position to the one pointed to by `addr`
 
-  def readByte(): Int        = { val b = nextByte; bp += 1; b } // Read a byte of data
+  def readByte(): Int = { val b = nextByte; bp += 1; b } // Read a byte of data
 
   /** Read the next `n` bytes of `data`. */
   def readBytes(n: Int): Array[Byte] = {

--- a/core/src/main/scala/com/typesafe/tools/mima/core/TastyReader.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/TastyReader.scala
@@ -24,6 +24,7 @@ final class TastyReader(val bytes: Array[Byte], start: Int, end: Int, val base: 
   def readAddr(): Addr       = Addr(readNat())      // Read a natural number and return as an address
   def readEnd(): Addr        = addr(readNat() + bp) // Read a length number and return the absolute end address implied by it, given as (address following length field) + (length-value-read)
   def goto(addr: Addr): Unit = bp = index(addr)     // Set read position to the one pointed to by `addr`
+
   def readByte(): Int        = { val b = nextByte; bp += 1; b } // Read a byte of data
 
   /** Read the next `n` bytes of `data`. */
@@ -50,6 +51,7 @@ final class TastyReader(val bytes: Array[Byte], start: Int, end: Int, val base: 
   /** Read a long integer number in 2's complement big endian format, base 128. */
   def readLongInt(): Long = {
     var b = bytes(bp)
+
     var x: Long = (b << 1).toByte >> 1 // sign extend with bit 6.
     bp += 1
     while ((b & 0x80) == 0) {
@@ -92,6 +94,7 @@ final class TastyReader(val bytes: Array[Byte], start: Int, end: Int, val base: 
 
   def assertSoft(cond: Boolean, msg: => String)  = if (!cond) println(msg)
   def assertShort(cond: Boolean, msg: => String) = if (!cond) shortExc(s"$msg")
+
   def shortExc(msg: String) = throw new Exception(msg, null, false, false) {}
 
   /** If before given `end` address, the result of `op`, otherwise `default` */

--- a/core/src/main/scala/com/typesafe/tools/mima/core/TastyRefs.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/TastyRefs.scala
@@ -3,8 +3,8 @@ package com.typesafe.tools.mima.core
 object TastyRefs {
   /** An address pointing to an index in a TASTy buffer's byte array */
   case class Addr(index: Int) extends AnyVal {
-    def - (delta: Int): Addr = Addr(index - delta)
-    def + (delta: Int): Addr = Addr(index + delta)
+    def -(delta: Int): Addr = Addr(index - delta)
+    def +(delta: Int): Addr = Addr(index + delta)
 
     def relativeTo(base: Addr): Addr = this - base.index - AddrWidth
 

--- a/core/src/main/scala/com/typesafe/tools/mima/core/TastyTagOps.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/TastyTagOps.scala
@@ -1,3 +1,5 @@
+// scalafmt cannot reproduce the hand-aligned columns below
+// format: off
 package com.typesafe.tools.mima.core
 
 import TastyFormat._, NameTags._

--- a/core/src/main/scala/com/typesafe/tools/mima/core/TastyUnpickler.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/TastyUnpickler.scala
@@ -3,7 +3,7 @@ package com.typesafe.tools.mima.core
 
 import java.util.UUID
 
-import scala.annotation.{nowarn, tailrec}
+import scala.annotation.{ nowarn, tailrec }
 import scala.collection.mutable, mutable.{ ArrayBuffer, ListBuffer }
 
 import TastyFormat._, NameTags._, TastyTagOps._, TastyRefs._
@@ -11,9 +11,9 @@ import TastyFormat._, NameTags._, TastyTagOps._, TastyRefs._
 object TastyUnpickler {
   def unpickleClass(in: TastyReader, clazz: ClassInfo, path: String): Unit = {
     val doPrint = false
-    //val doPrint = true
-    //val doPrint = path.contains("v1") && !path.contains("exclude.tasty")
-    //if (doPrint) TastyPrinter.printClassNames(in.fork, path)
+    // val doPrint = true
+    // val doPrint = path.contains("v1") && !path.contains("exclude.tasty")
+    // if (doPrint) TastyPrinter.printClassNames(in.fork, path)
     if (doPrint) TastyPrinter.printPickle(in.fork, path)
 
     readHeader(in)
@@ -163,7 +163,7 @@ object TastyUnpickler {
           val end  = readEnd()
           val name = readName()
           while (nextByte == TYPEPARAM || nextByte == PARAM || nextByte == EMPTYCLAUSE || nextByte == SPLITCLAUSE) skipTree(readByte()) // params
-          skipTree(readByte()) // returnType
+          skipTree(readByte())                                                                                                          // returnType
 
           if (!nothingButMods(end)) skipTree(readByte()) // rhs
           val (privateWithin, classPrivate, annots) = readMods(end)
@@ -179,18 +179,21 @@ object TastyUnpickler {
           // Self      = SELFDEF     selfName_NameRef selfType_Term      -- selfName : selfType
           assert(readByte() == TEMPLATE)
           val end = readEnd()
-          while (nextByte == TYPEPARAM)                                                   skipTree(readByte()) // vparams
+          while (nextByte == TYPEPARAM) skipTree(readByte())                                                   // vparams
           while (nextByte == PARAM || nextByte == EMPTYCLAUSE || nextByte == SPLITCLAUSE) skipTree(readByte()) // tparams
-          while (nextByte != SELFDEF && nextByte != DEFDEF)                               skipTree(readByte()) // parents
+          while (nextByte != SELFDEF && nextByte != DEFDEF) skipTree(readByte())                               // parents
           if (nextByte == SELFDEF) skipTree(readByte())                                                        // self
           val classes = new ListBuffer[ClsDef]
-          val fields = new ListBuffer[ValDef]
-          val meths = new ListBuffer[DefDef]
+          val fields  = new ListBuffer[ValDef]
+          val meths   = new ListBuffer[DefDef]
           doUntil(end)(readByte() match {
-            case TYPEDEF => readTypeDef() match { case clsDef: ClsDef => classes += clsDef case _ => }
-            case  VALDEF => fields += readValDef()
-            case  DEFDEF => meths  += readDefDef()
-            case tag     => skipTree(tag)
+            case TYPEDEF => readTypeDef() match {
+                case clsDef: ClsDef => classes += clsDef
+                case _              =>
+              }
+            case VALDEF => fields += readValDef()
+            case DEFDEF => meths += readDefDef()
+            case tag    => skipTree(tag)
           })
           Template(classes.toList, fields.toList, meths.toList)
         }
@@ -209,8 +212,8 @@ object TastyUnpickler {
           //   PRIVATEqualified qualifier_Type --   private[qualifier]
           // PROTECTEDqualified qualifier_Type -- protected[qualifier]
           var privateWithin = Option.empty[Type]
-          var classPrivate = false
-          val annots = new ListBuffer[Annot]
+          var classPrivate  = false
+          val annots        = new ListBuffer[Annot]
           doUntil(end)(readByte() match {
             case ANNOTATION                => annots += readAnnot()
             case PRIVATEqualified          => privateWithin = Some(readType())
@@ -228,7 +231,7 @@ object TastyUnpickler {
           if (nextByte == TEMPLATE) readClassDef(name, end) else readTypeMemberDef(end)
         }
 
-        val end = fork.readEnd()
+        val end  = fork.readEnd()
         val tree = tag match {
           case PACKAGE => readPackage()
           case TYPEDEF => readTypeDef()
@@ -241,17 +244,17 @@ object TastyUnpickler {
       astCategory(tag) match {
         case AstCat1TagOnly => skipTree(tag)
         case AstCat2Nat     => tag match {
-          case TERMREFpkg => readTypeRefPkg()
-          case TYPEREFpkg => readTypeRefPkg()
-          case _          => skipTree(tag)
-        }
-        case AstCat3AST     => readTree()
-        case AstCat4NatAST  => tag match {
-          case TYPEREFsymbol => skipTree(tag) match { case UnknownTree(tag) => UnknownType(tag) }
-          case TYPEREF       => readTypeRef()
-          case _             => skipTree(tag)
-        }
-        case AstCat5Length  => processLengthTree()
+            case TERMREFpkg => readTypeRefPkg()
+            case TYPEREFpkg => readTypeRefPkg()
+            case _          => skipTree(tag)
+          }
+        case AstCat3AST    => readTree()
+        case AstCat4NatAST => tag match {
+            case TYPEREFsymbol => skipTree(tag) match { case UnknownTree(tag) => UnknownType(tag) }
+            case TYPEREF       => readTypeRef()
+            case _             => skipTree(tag)
+          }
+        case AstCat5Length => processLengthTree()
       }
     }
 
@@ -273,8 +276,8 @@ object TastyUnpickler {
 
   final case class UnknownTree(tag: Int) extends Tree {
     val stack = new Exception().getStackTrace
-    val id = unknownTreeId.getAndIncrement()
-    def show = s"UnknownTree(${astTagToString(tag)})" //+ s"#$id"
+    val id    = unknownTreeId.getAndIncrement()
+    def show  = s"UnknownTree(${astTagToString(tag)})" // + s"#$id"
   }
   var unknownTreeId = new java.util.concurrent.atomic.AtomicInteger()
 
@@ -283,7 +286,7 @@ object TastyUnpickler {
   final case class ClsDef(name: TypeName, template: Template, privateWithin: Option[Type], annots: List[Annot]) extends Tree {
     def show = s"${showXs(annots, end = " ")}${showPrivateWithin(privateWithin)}class $name$template"
   }
-  final case class Template(classes: List[ClsDef], fields: List[ValDef], meths: List[DefDef]) extends Tree { def show = s"${(classes ::: meths).map("\n  " + _).mkString}" }
+  final case class Template(classes: List[ClsDef], fields: List[ValDef], meths: List[DefDef])                        extends Tree { def show = s"${(classes ::: meths).map("\n  " + _).mkString}" }
   final case class ValDef(name: Name, privateWithin: Option[Type], classPrivate: Boolean, annots: List[Annot] = Nil) extends TermMemberDef
   final case class DefDef(name: Name, privateWithin: Option[Type], classPrivate: Boolean, annots: List[Annot] = Nil) extends TermMemberDef
 
@@ -295,7 +298,7 @@ object TastyUnpickler {
   sealed trait Type extends Tree
 
   final case class UnknownType(tag: Int)           extends Type { def show = s"UnknownType(${astTagToString(tag)})" }
-  final case class TypeRef(qual: Type, name: Name) extends Type { def show = s"$qual.$name" }
+  final case class TypeRef(qual: Type, name: Name) extends Type { def show = s"$qual.$name"                         }
 
   sealed trait Path extends Type
 
@@ -311,14 +314,14 @@ object TastyUnpickler {
 
   sealed class Traverser {
     def traverse(tree: Tree): Unit = tree match {
-      case pkg: Pkg        => traversePkg(pkg)
-      case clsDef: ClsDef  => traverseClsDef(clsDef)
-      case tmpl: Template  => traverseTemplate(tmpl)
-      case valDef: ValDef  => traverseValDef(valDef)
-      case defDef: DefDef  => traverseDefDef(defDef)
-      case tp: Type        => traverseType(tp)
-      case annot: Annot    => traverseAnnot(annot)
-      case UnknownTree(_)  =>
+      case pkg: Pkg       => traversePkg(pkg)
+      case clsDef: ClsDef => traverseClsDef(clsDef)
+      case tmpl: Template => traverseTemplate(tmpl)
+      case valDef: ValDef => traverseValDef(valDef)
+      case defDef: DefDef => traverseDefDef(defDef)
+      case tp: Type       => traverseType(tp)
+      case annot: Annot   => traverseAnnot(annot)
+      case UnknownTree(_) =>
     }
 
     def traverseName(name: Name) = ()
@@ -330,8 +333,8 @@ object TastyUnpickler {
     def traverseDefDef(defDef: DefDef)                     = { val DefDef(name, privateWithin, _, annots) = defDef; traverseName(name); traversePrivateWithin(privateWithin); annots.foreach(traverse) }
     def traversePrivateWithin(privateWithin: Option[Type]) = { privateWithin.foreach(traverseType) }
 
-    //def traverseClassPrivate(classPrivate: Boolean)        =     { privateWithin.foreach(traverseType) }
-    def traverseAnnot(annot: Annot)                        = { val Annot(tycon, fullAnnotation) = annot; traverse(tycon); traverse(fullAnnotation) }
+    // def traverseClassPrivate(classPrivate: Boolean)        =     { privateWithin.foreach(traverseType) }
+    def traverseAnnot(annot: Annot) = { val Annot(tycon, fullAnnotation) = annot; traverse(tycon); traverse(fullAnnotation) }
 
     def traversePath(path: Path) = path match {
       case TypeRefPkg(fullyQual) => traverseName(fullyQual)
@@ -396,7 +399,8 @@ object TastyUnpickler {
     val end = readEnd()
 
     def nameAtIdx(idx: Int) =
-      try names(idx) catch {
+      try names(idx)
+      catch {
         case e: ArrayIndexOutOfBoundsException =>
           throw new Exception(s"trying to read name @ idx=$idx tag=${nameTagToString(tag)}", e)
       }
@@ -413,23 +417,23 @@ object TastyUnpickler {
     }
 
     val name = tag match {
-      case UTF8           => val start = currentAddr; goto(end); SimpleName(new String(bytes.slice(start.index, end.index), "UTF-8"))
-      case QUALIFIED      => QualifiedName(readName(),         Name.PathSep, readName().asSimpleName)
-      case EXPANDED       => QualifiedName(readName(),     Name.ExpandedSep, readName().asSimpleName)
-      case EXPANDPREFIX   => QualifiedName(readName(), Name.ExpandPrefixSep, readName().asSimpleName)
+      case UTF8         => val start = currentAddr; goto(end); SimpleName(new String(bytes.slice(start.index, end.index), "UTF-8"))
+      case QUALIFIED    => QualifiedName(readName(), Name.PathSep, readName().asSimpleName)
+      case EXPANDED     => QualifiedName(readName(), Name.ExpandedSep, readName().asSimpleName)
+      case EXPANDPREFIX => QualifiedName(readName(), Name.ExpandPrefixSep, readName().asSimpleName)
 
-      case UNIQUE         => UniqueName(sep = readName().asSimpleName, num = readNat(), qual = ifBefore(end)(readName(), Name.Empty))
-      case DEFAULTGETTER  => DefaultName(readName(), readNat())
+      case UNIQUE        => UniqueName(sep = readName().asSimpleName, num = readNat(), qual = ifBefore(end)(readName(), Name.Empty))
+      case DEFAULTGETTER => DefaultName(readName(), readNat())
 
-      case SUPERACCESSOR  => PrefixName( Name.SuperPrefix, readName())
+      case SUPERACCESSOR  => PrefixName(Name.SuperPrefix, readName())
       case INLINEACCESSOR => PrefixName(Name.InlinePrefix, readName())
       case BODYRETAINER   => SuffixName(readName(), Name.BodyRetainerSuffix)
       case OBJECTCLASS    => ObjectName(readName())
 
-      case SIGNED         => val name = readName(); readSignedRest(name, name)
-      case TARGETSIGNED   => readSignedRest(readName(), readName())
+      case SIGNED       => val name = readName(); readSignedRest(name, name)
+      case TARGETSIGNED => readSignedRest(readName(), readName())
 
-      case _              => sys.error(s"at NameRef(${names.size}): name `${readName().debug}` is qualified by tag ${nameTagToString(tag)}")
+      case _ => sys.error(s"at NameRef(${names.size}): name `${readName().debug}` is qualified by tag ${nameTagToString(tag)}")
     }
     assertEnd(end, s" bad name=${name.debug}")
     name
@@ -456,8 +460,8 @@ object TastyUnpickler {
     final def show = source
   }
 
-  final case class SimpleName(raw: String)                                                   extends Name
-  final case class ObjectName(base: Name)                                                    extends Name
+  final case class SimpleName(raw: String) extends Name
+  final case class ObjectName(base: Name)  extends Name
   @nowarn("msg=constructor modifiers are assumed by synthetic")
   final case class TypeName private[TastyUnpickler] (base: Name)                             extends Name
   final case class QualifiedName(qual: Name, sep: SimpleName, sel: SimpleName)               extends Name
@@ -569,10 +573,10 @@ object TastyUnpickler {
   }
 
   final case class Header(
-    header: (Int, Int, Int, Int),
-    version: (Int, Int, Int),
-    toolingVersion: String,
-    uuid: UUID,
+      header: (Int, Int, Int, Int),
+      version: (Int, Int, Int),
+      toolingVersion: String,
+      uuid: UUID,
   )
 
   def readHeader(in: TastyReader): Header = {
@@ -587,10 +591,10 @@ object TastyUnpickler {
     }
 
     Header(
-      header         = (readByte(), readByte(), readByte(), readByte()),
-      version        = (readNat(), readNat(), readNat()),
+      header = (readByte(), readByte(), readByte(), readByte()),
+      version = (readNat(), readNat(), readNat()),
       toolingVersion = readToolingVersion(),
-      uuid           = new UUID(readUncompressedLong(), readUncompressedLong()),
+      uuid = new UUID(readUncompressedLong(), readUncompressedLong()),
     )
   }
 

--- a/core/src/main/scala/com/typesafe/tools/mima/core/TastyUnpickler.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/TastyUnpickler.scala
@@ -1,3 +1,4 @@
+// scalafmt: { maxColumn = 230, align.preset = more }
 package com.typesafe.tools.mima.core
 
 import java.util.UUID
@@ -50,6 +51,7 @@ object TastyUnpickler {
       val pkgName = pkgNames.headOption.getOrElse(nme.Empty)
       if (pkgName.source == pkgInfo.fullName) {
         val clsName0 = clsNames.reverseIterator.mkString("$")
+
         val clsName = clsNames match {
           case TypeName(ObjectName(_)) :: _ => clsName0 + "$"
           case _                            => clsName0
@@ -149,6 +151,7 @@ object TastyUnpickler {
           val end  = readEnd()
           val name = readName()
           skipTree(readByte()) // type
+
           if (!nothingButMods(end)) skipTree(readByte()) // rhs
           val (privateWithin, classPrivate, annots) = readMods(end)
           ValDef(name, privateWithin, classPrivate, annots)
@@ -161,6 +164,7 @@ object TastyUnpickler {
           val name = readName()
           while (nextByte == TYPEPARAM || nextByte == PARAM || nextByte == EMPTYCLAUSE || nextByte == SPLITCLAUSE) skipTree(readByte()) // params
           skipTree(readByte()) // returnType
+
           if (!nothingButMods(end)) skipTree(readByte()) // rhs
           val (privateWithin, classPrivate, annots) = readMods(end)
           DefDef(name, privateWithin, classPrivate, annots)
@@ -194,6 +198,7 @@ object TastyUnpickler {
         def readClassDef(name: Name, end: Addr) = {
           // NameRef Template Modifier* -- modifiers class name template
           val template = readTemplate()
+
           val (privateWithin, classPrivate, annots) = readMods(end)
           ClsDef(name.toTypeName, template, privateWithin, annots)
         }
@@ -288,10 +293,12 @@ object TastyUnpickler {
   }
 
   sealed trait Type extends Tree
+
   final case class UnknownType(tag: Int)           extends Type { def show = s"UnknownType(${astTagToString(tag)})" }
   final case class TypeRef(qual: Type, name: Name) extends Type { def show = s"$qual.$name" }
 
   sealed trait Path extends Type
+
   final case class UnknownPath(tag: Int)       extends Path { def show = s"UnknownPath(${astTagToString(tag)})" }
   final case class TypeRefPkg(fullyQual: Name) extends Path { def show = s"$fullyQual"                          }
 
@@ -344,11 +351,13 @@ object TastyUnpickler {
 
   class FilterTraverser(p: Tree => Boolean) extends Traverser {
     val hits = mutable.ListBuffer[Tree]()
+
     override def traverse(t: Tree) = { if (p(t)) hits += t; super.traverse(t) }
   }
 
   class CollectTraverser[T](pf: PartialFunction[Tree, T]) extends Traverser {
     val results = mutable.ListBuffer[T]()
+
     override def traverse(tree: Tree): Unit = { pf.runWith(results += _)(tree); super.traverse(tree) }
   }
 
@@ -386,10 +395,11 @@ object TastyUnpickler {
     val tag = readByte()
     val end = readEnd()
 
-    def nameAtIdx(idx: Int) = try names(idx) catch {
-      case e: ArrayIndexOutOfBoundsException =>
-        throw new Exception(s"trying to read name @ idx=$idx tag=${nameTagToString(tag)}", e)
-    }
+    def nameAtIdx(idx: Int) =
+      try names(idx) catch {
+        case e: ArrayIndexOutOfBoundsException =>
+          throw new Exception(s"trying to read name @ idx=$idx tag=${nameTagToString(tag)}", e)
+      }
 
     def readName() = nameAtIdx(readNat())
 
@@ -451,13 +461,10 @@ object TastyUnpickler {
   @nowarn("msg=constructor modifiers are assumed by synthetic")
   final case class TypeName private[TastyUnpickler] (base: Name)                             extends Name
   final case class QualifiedName(qual: Name, sep: SimpleName, sel: SimpleName)               extends Name
-
   final case class UniqueName(qual: Name, sep: SimpleName, num: Int)                         extends Name
   final case class DefaultName(qual: Name, num: Int)                                         extends Name
-
   final case class PrefixName(pref: SimpleName, qual: Name)                                  extends Name
   final case class SuffixName(qual: Name, suff: SimpleName)                                  extends Name
-
   final case class SignedName(qual: Name, sig: MethodSignature[ErasedTypeRef], target: Name) extends Name
 
   object Name {
@@ -573,6 +580,7 @@ object TastyUnpickler {
 
     def readToolingVersion() = {
       val toolingLen = readNat()
+
       val toolingVersion = new String(bytes, currentAddr.index, toolingLen)
       goto(currentAddr + toolingLen)
       toolingVersion

--- a/core/src/main/scala/com/typesafe/tools/mima/core/TastyVersionCompatibility.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/TastyVersionCompatibility.scala
@@ -38,8 +38,8 @@ object TastyVersionCompatibility {
    */
   def isVersionCompatible(fileMajor: Int, fileMinor: Int, fileExperimental: Int): Boolean = (
     fileMajor == MajorVersion &&
-      (  fileMinor == MinorVersion && fileExperimental == ExperimentalVersion // full equality
-      || fileMinor <  MinorVersion && fileExperimental == 0 // stable backwards compatibility
-    )
+      (fileMinor == MinorVersion && fileExperimental == ExperimentalVersion // full equality
+        || fileMinor < MinorVersion && fileExperimental == 0                // stable backwards compatibility
+      )
   )
 }

--- a/core/src/main/scala/com/typesafe/tools/mima/core/util/log/ConsoleLogging.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/util/log/ConsoleLogging.scala
@@ -2,7 +2,6 @@ package com.typesafe.tools.mima.core.util.log
 
 private[mima] object ConsoleLogging extends Logging {
   private final val debug  = false
-
   def verbose(msg: String) = debug(msg)
   def debug(msg: String)   = if (debug) Console.out.println(msg)
   def warn(msg: String)    = Console.out.println(msg)

--- a/core/src/main/scala/com/typesafe/tools/mima/lib/MiMaLib.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/lib/MiMaLib.scala
@@ -1,3 +1,4 @@
+// scalafmt: { maxColumn = 150, align.preset = some }
 package com.typesafe.tools.mima.lib
 
 import java.io.File

--- a/core/src/main/scala/com/typesafe/tools/mima/lib/analyze/field/FieldChecker.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/lib/analyze/field/FieldChecker.scala
@@ -8,7 +8,8 @@ private[analyze] object FieldChecker {
   }
 
   private def check1(oldfld: FieldInfo, newclazz: ClassInfo): Option[Problem] = {
-    if (oldfld.nonAccessible) None else {
+    if (oldfld.nonAccessible) None
+    else {
       val newflds = newclazz.lookupClassFields(oldfld)
       if (newflds.hasNext) {
         val newfld = newflds.next()
@@ -17,8 +18,7 @@ private[analyze] object FieldChecker {
         else if (oldfld.isStatic && !newfld.isStatic) Some(StaticVirtualMemberProblem(oldfld))
         else if (!oldfld.isStatic && newfld.isStatic) Some(VirtualStaticMemberProblem(oldfld))
         else None
-      }
-      else Some(MissingFieldProblem(oldfld))
+      } else Some(MissingFieldProblem(oldfld))
     }
   }
 }

--- a/core/src/main/scala/com/typesafe/tools/mima/lib/analyze/method/MethodChecker.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/lib/analyze/method/MethodChecker.scala
@@ -1,3 +1,4 @@
+// scalafmt: { maxColumn = 150, align.preset = some }
 package com.typesafe.tools.mima.lib.analyze.method
 
 import com.typesafe.tools.mima.core._

--- a/core/src/main/scala/com/typesafe/tools/mima/lib/analyze/method/MethodChecker.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/lib/analyze/method/MethodChecker.scala
@@ -163,8 +163,8 @@ private[analyze] object MethodChecker {
       if !excludeAnnots.exists(newDeferredMethod.annotations.contains)
       // checks that the newDeferredMethod did not already exist in one of the oldclazz supertypes
       if noInheritedMatchingMethod(oldclazz, newDeferredMethod)(_ => true) &&
-          // checks that no concrete implementation of the newDeferredMethod is provided by one of the newclazz supertypes
-          noInheritedMatchingMethod(newclazz, newDeferredMethod)(_.isConcrete)
+        // checks that no concrete implementation of the newDeferredMethod is provided by one of the newclazz supertypes
+        noInheritedMatchingMethod(newclazz, newDeferredMethod)(_.isConcrete)
     } yield {
       // report a binary incompatibility as there is a new inherited abstract method, which can lead to a AbstractErrorMethod at runtime
       val newmeth = new MethodInfo(newclazz, newDeferredMethod.bytecodeName, newDeferredMethod.flags, newDeferredMethod.descriptor)

--- a/core/src/main/scala/com/typesafe/tools/mima/lib/analyze/template/TemplateChecker.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/lib/analyze/template/TemplateChecker.scala
@@ -1,3 +1,4 @@
+// scalafmt: { align.preset = none  }
 package com.typesafe.tools.mima.lib.analyze.template
 
 import com.typesafe.tools.mima.core._

--- a/core/src/test/scala/com/typesafe/tools/mima/core/ProblemFiltersSpec.scala
+++ b/core/src/test/scala/com/typesafe/tools/mima/core/ProblemFiltersSpec.scala
@@ -1,3 +1,4 @@
+// scalafmt: { align.tokens."+" = [ { code = "," } ] }
 package com.typesafe.tools.mima.core
 
 final class ProblemFiltersSpec extends munit.FunSuite {

--- a/core/src/test/scala/com/typesafe/tools/mima/core/ProblemReportingSpec.scala
+++ b/core/src/test/scala/com/typesafe/tools/mima/core/ProblemReportingSpec.scala
@@ -1,18 +1,18 @@
 package com.typesafe.tools.mima.core
 
 final class ProblemReportingSpec extends munit.FunSuite {
-  test("isReported should handle no filters")       (assert(isReported(Nil)))
-  test("isReported should handle filters")          (assert(!isReported(List(excludeAll))))
+  test("isReported should handle no filters")(assert(isReported(Nil)))
+  test("isReported should handle filters")(assert(!isReported(List(excludeAll))))
 
-  test("isReported should handle version filter")   (assert(!isReportedV("0.0.1", "0.0.1")))
-  test("isReported should handle wildcard")         (assert(!isReportedV("0.0.1", "0.0.x")))
-  test("isReported should handle no patch segment") (assert(!isReportedV("0.1", "0.1")))
-  test("isReported should handle only major")       (assert(!isReportedV("1", "1")))
-  test("isReported should handle less segments")    (assert(!isReportedV("0.1.0", "0.1")))
-  test("isReported should handle more segments")    (assert(!isReportedV("0.1", "0.1.0")))
+  test("isReported should handle version filter")(assert(!isReportedV("0.0.1", "0.0.1")))
+  test("isReported should handle wildcard")(assert(!isReportedV("0.0.1", "0.0.x")))
+  test("isReported should handle no patch segment")(assert(!isReportedV("0.1", "0.1")))
+  test("isReported should handle only major")(assert(!isReportedV("1", "1")))
+  test("isReported should handle less segments")(assert(!isReportedV("0.1.0", "0.1")))
+  test("isReported should handle more segments")(assert(!isReportedV("0.1", "0.1.0")))
 
-  test("isReported should handle later version")    (assert(!isReportedV("1.2.3", filterVersion = "1.9.9")))
-  test("isReported should handle earlier version")  (assert(isReportedV("1.2.3", filterVersion = "1.1.6")))
+  test("isReported should handle later version")(assert(!isReportedV("1.2.3", filterVersion = "1.9.9")))
+  test("isReported should handle earlier version")(assert(isReportedV("1.2.3", filterVersion = "1.1.6")))
 
   private def isReported(filters: List[ProblemFilter]) = helper("0.0.1", filters, Map.empty)
 

--- a/core/src/test/scala/com/typesafe/tools/mima/core/SignatureSpec.scala
+++ b/core/src/test/scala/com/typesafe/tools/mima/core/SignatureSpec.scala
@@ -4,10 +4,10 @@ final class SignatureSpec extends munit.FunSuite {
   val promiseSig =
     "Lscala/concurrent/Promise<" +
       "Lscala/Function1<" +
-        "Lscala/concurrent/duration/FiniteDuration;" +
-        "Lscala/concurrent/Future<Lakka/http/scaladsl/Http$HttpTerminated;>;" +
+      "Lscala/concurrent/duration/FiniteDuration;" +
+      "Lscala/concurrent/Future<Lakka/http/scaladsl/Http$HttpTerminated;>;" +
       ">;" +
-    ">;"
+      ">;"
 
   val `signature_in_2.12.8` = Signature(s"(Lakka/http/impl/engine/server/GracefulTerminatorStage;$promiseSig)V")
   val `signature_in_2.12.9` = Signature(s"($promiseSig)V")

--- a/core/src/test/scala/com/typesafe/tools/mima/core/SignatureSpec.scala
+++ b/core/src/test/scala/com/typesafe/tools/mima/core/SignatureSpec.scala
@@ -35,6 +35,7 @@ final class SignatureSpec extends munit.FunSuite {
     import Signature.FormalTypeParameter
     val rest = "(TT;Lscala/collection/immutable/List<TU;>;)Lscala/Option<TT;>;>"
     val orig = s"T:Ljava/lang/Object;U:Lscala/collection/immutable/List<TT;>;>$rest"
+
     val (types, obtRest) = FormalTypeParameter.parseList(orig)
     assertEquals(types.length, 2)
     assertEquals(types(0), FormalTypeParameter("T", "Ljava/lang/Object"))

--- a/functional-tests/src/it/scala/IntegrationTestSuite.scala
+++ b/functional-tests/src/it/scala/IntegrationTestSuite.scala
@@ -259,7 +259,6 @@ class IntegrationTestSuite extends munit.FunSuite {
     ),
   ).get)
 
-
   test("scala-reflect-2-10")(testIntegration("org.scala-lang", "scala-reflect", "2.10.0", "2.10.7")(
     expected = List(
       "static method currentMirror()scala.reflect.api.JavaMirrors#JavaMirror in class scala.reflect.runtime.package does not have a correspondent in new version",

--- a/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/AppRunTest.scala
+++ b/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/AppRunTest.scala
@@ -24,7 +24,7 @@ object AppRunTest {
       case _                     => Success(())
     }
     () <- testCase.runMain(v2) match { // test: run app, compiled with v1, with v2
-      case Failure(t)  if !pending &&  expectOk => Failure(t)
+      case Failure(t) if !pending && expectOk   => Failure(t)
       case Success(()) if !pending && !expectOk => Failure(new Exception("expected running App to fail"))
       case _                                    => Success(())
     }

--- a/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/AppRunTest.scala
+++ b/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/AppRunTest.scala
@@ -1,3 +1,4 @@
+// scalafmt: { align.preset = more }
 package com.typesafe.tools.mima.lib
 
 import scala.reflect.io.{ Directory, Path }
@@ -15,8 +16,8 @@ object AppRunTest {
     insane   = testCase.versionedFile("testAppRun.insane").exists
     pending  = testCase.versionedFile("testAppRun.pending").exists
     expectOk = testCase.blankFile(testCase.versionedFile(oracleFile))
-  //() <- testCase.compileApp(v2)      // compile app with v2
-  //() <- testCase.runMain(v2)         // sanity check 1: run app with v2
+//    () <- testCase.compileApp(v2)      // compile app with v2
+//    () <- testCase.runMain(v2)         // sanity check 1: run app with v2
     () <- testCase.compileApp(v1)      // recompile app with v1
     () <- testCase.runMain(v1) match { // sanity check 2: run app with v1
       case Failure(t) if !insane => Failure(new Exception("Sanity runMain check failed", t, true, false) {})

--- a/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/CollectProblemsTest.scala
+++ b/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/CollectProblemsTest.scala
@@ -17,15 +17,15 @@ object CollectProblemsTest {
     () <- collectAndDiff(cp = Nil, v1.jfile, v2.jfile)(
       expected,
       excludeAnnots = excludeAnnots,
-      direction     = direction,
+      direction = direction,
     )
   } yield ()
 
   def collectAndDiff(cp: Seq[File], v1: File, v2: File)(
-      expected: List[String]              = Nil,
+      expected: List[String] = Nil,
       problemFilters: List[ProblemFilter] = Nil,
-      excludeAnnots: List[String]         = Nil,
-      direction: Direction                = Backwards,
+      excludeAnnots: List[String] = Nil,
+      direction: Direction = Backwards,
   ): Try[Unit] = {
     val problems = new MiMaLib(cp).collectProblems(v1, v2, excludeAnnots).filter(problemFilters.foldAll)
     val affectedVersion = direction match {

--- a/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/CollectProblemsTest.scala
+++ b/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/CollectProblemsTest.scala
@@ -1,3 +1,4 @@
+// scalafmt: { align.preset = some, spaces.inImportCurlyBraces = false  }
 package com.typesafe.tools.mima.lib
 
 import java.io.File

--- a/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/Coursier.scala
+++ b/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/Coursier.scala
@@ -7,6 +7,7 @@ import coursier._
 object Coursier {
   val scalaEA = mvn"https://scala-ci.typesafe.com/artifactory/scala-integration/"
   val scalaPR = mvn"https://scala-ci.typesafe.com/artifactory/scala-pr-validation-snapshots/"
+
   val sbtPluginReleases = Repositories.sbtPlugin("releases")
 
   def fetch(dep: Dependency): Seq[File] = {

--- a/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/Direction.scala
+++ b/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/Direction.scala
@@ -11,4 +11,4 @@ sealed trait Direction {
   }
 }
 case object Backwards extends Direction
-case object  Forwards extends Direction
+case object Forwards  extends Direction

--- a/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/IntegrationTests.scala
+++ b/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/IntegrationTests.scala
@@ -11,16 +11,16 @@ import CollectProblemsTest._, IntegrationTests._
 
 object IntegrationTests {
   def testIntegration(groupId: String, artifactId: String, v1: String, v2: String)(
-      expected: List[String]              = Nil,
+      expected: List[String] = Nil,
       problemFilters: List[ProblemFilter] = Nil,
-      excludeAnnots: List[String]         = Nil,
-      moduleAttrs: Map[String, String]    = Map.empty,
+      excludeAnnots: List[String] = Nil,
+      moduleAttrs: Map[String, String] = Map.empty,
   ) = {
     val module = Module(Organization(groupId), ModuleName(artifactId), moduleAttrs)
     for {
-      (v1, _)  <- fetchArtifact(Dependency(module, v1))
+      (v1, _) <- fetchArtifact(Dependency(module, v1))
       (v2, cp) <- fetchArtifact(Dependency(module, v2))
-      ()       <- collectAndDiff(cp, v1, v2)(expected, problemFilters, excludeAnnots)
+      () <- collectAndDiff(cp, v1, v2)(expected, problemFilters, excludeAnnots)
     } yield ()
   }
 
@@ -37,7 +37,9 @@ object CompareJars {
     case Seq(file) =>
       runTry(collectAndDiff(Nil, new File(file), new File(file))())
     case Seq(groupId, artifactId, v1, v2, attrStrs @ _*) =>
-      val attrs = attrStrs.map { s => val Array(k, v) = s.split('='); k -> v }.toMap
+      val attrs = attrStrs.map { s =>
+        val Array(k, v) = s.split('='); k -> v
+      }.toMap
       runTry(testIntegration(groupId, artifactId, v1, v2)(moduleAttrs = attrs))
   }
 

--- a/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/ScalaCompiler.scala
+++ b/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/ScalaCompiler.scala
@@ -21,14 +21,14 @@ final class ScalaCompiler(val version: String) {
   def compile(args: Seq[String]): Try[Unit] = {
     import scala.language.reflectiveCalls
     val clsName = if (isScala3) "dotty.tools.dotc.Main$" else "scala.tools.nsc.Main$"
-    val cls = classLoader.loadClass(clsName)
+    val cls     = classLoader.loadClass(clsName)
     type Main     = { def process(args: Array[String]): Any; def reporter: Reporter }
     type Reporter = { def hasErrors: Boolean }
     val m = cls.getField("MODULE$").get(null).asInstanceOf[Main]
     Try {
       val success = m.process(args.toArray) match {
         case b: Boolean => b
-        case null       => !m.reporter.hasErrors // nsc 2.11
+        case null       => !m.reporter.hasErrors               // nsc 2.11
         case x          => !x.asInstanceOf[Reporter].hasErrors // dotc
       }
       if (success) Success(()) else Failure(new Exception("scalac failed"))

--- a/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/TestCase.scala
+++ b/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/TestCase.scala
@@ -64,7 +64,7 @@ final class TestCase(val baseDir: Directory, val scalaCompiler: ScalaCompiler, v
     val sourceFiles = lsSrcs(srcDir, _.hasExtension("java"))
     if (sourceFiles.isEmpty) return Success(())
     val cpStr = ClassPath.join((scalaJars ++ cp.map(_.jfile)).map(_.getPath))
-    val opts = List("-classpath", cpStr, "-d", s"$out").asJava
+    val opts  = List("-classpath", cpStr, "-d", s"$out").asJava
     val units = sourceFiles.map { sf =>
       new SimpleJavaFileObject(new URI(s"string:///${sf.path}"), JavaFileObject.Kind.SOURCE) {
         override def getCharContent(ignoreEncodingErrors: Boolean): java.nio.CharBuffer =
@@ -125,12 +125,12 @@ final class TestCase(val baseDir: Directory, val scalaCompiler: ScalaCompiler, v
     val p211 = (p.parent / (s"${p.stripExtension}-2.11")).addExtension(p.extension).toFile
     val p212 = (p.parent / (s"${p.stripExtension}-2.12")).addExtension(p.extension).toFile
     val p213 = (p.parent / (s"${p.stripExtension}-2.13")).addExtension(p.extension).toFile
-    val p3   = (p.parent / (s"${p.stripExtension}-3"   )).addExtension(p.extension).toFile
+    val p3   = (p.parent / (s"${p.stripExtension}-3")).addExtension(p.extension).toFile
     scalaBinaryVersion match {
       case "2.11" => if (p211.exists) p211 else if (p212.exists) p212 else p
       case "2.12" => if (p212.exists) p212 else p
       case "2.13" => if (p213.exists) p213 else if (p212.exists) p212 else p
-      case "3"    => if (p3.exists)   p3   else p
+      case "3"    => if (p3.exists) p3 else p
       case _      => p
     }
   }
@@ -144,9 +144,9 @@ final class TestCase(val baseDir: Directory, val scalaCompiler: ScalaCompiler, v
 
   @tailrec private def rootCause(x: Throwable): Throwable = x match {
     case _: ExceptionInInitializerError |
-         _: java.lang.reflect.InvocationTargetException |
-         _: java.lang.reflect.UndeclaredThrowableException |
-         _: java.util.concurrent.ExecutionException
+        _: java.lang.reflect.InvocationTargetException |
+        _: java.lang.reflect.UndeclaredThrowableException |
+        _: java.util.concurrent.ExecutionException
         if x.getCause != null =>
       rootCause(x.getCause)
     case _ => x

--- a/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/TestCase.scala
+++ b/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/TestCase.scala
@@ -1,3 +1,4 @@
+// scalafmt: { maxColumn = 150, align.preset = more, spaces.inImportCurlyBraces = false  }
 package com.typesafe.tools.mima.lib
 
 import com.typesafe.tools.mima.core.ClassPath
@@ -18,7 +19,6 @@ final class TestCase(val baseDir: Directory, val scalaCompiler: ScalaCompiler, v
   def name               = baseDir.name
   def scalaBinaryVersion = if (scalaCompiler.isScala3) "3" else scalaCompiler.version.take(4)
   def scalaJars          = scalaCompiler.jars
-
   def skip: Boolean      = (baseDir / s"skip-${scalaBinaryVersion}.txt").exists
 
   val srcV1  = (baseDir / "v1").toDirectory
@@ -47,6 +47,7 @@ final class TestCase(val baseDir: Directory, val scalaCompiler: ScalaCompiler, v
     if (sourceFiles.forall(_.isJava)) return Success(())
     val bootcp = ClassPath.join(scalaJars.map(_.getPath))
     val cpOpt  = if (cp.isEmpty) Nil else List("-classpath", ClassPath.join(cp.map(_.path)))
+
     val optsFile = baseDir / s"scalac-options-${scalaBinaryVersion}.txt"
     val testOpts = if (optsFile.exists) {
       Files.readAllLines(optsFile.jfile.toPath, StandardCharsets.UTF_8).asScala.filterNot(_.trim.startsWith("#")).toList
@@ -54,6 +55,7 @@ final class TestCase(val baseDir: Directory, val scalaCompiler: ScalaCompiler, v
       List.empty
     }
     val paths = sourceFiles.map(_.path)
+
     val args = "-bootclasspath" :: bootcp :: testOpts ::: cpOpt ::: "-d" :: s"$out" :: paths
     scalaCompiler.compile(args)
   }
@@ -70,7 +72,9 @@ final class TestCase(val baseDir: Directory, val scalaCompiler: ScalaCompiler, v
       }
     }.asJava
     val infos = new mutable.LinkedHashSet[Diagnostic[_ <: JavaFileObject]]
+
     val task = javaCompiler.getTask(null, null, d => infos += d, opts, null, units)
+
     val success = task.call() && infos.forall(_.getKind != Diagnostic.Kind.ERROR)
     if (success) Success(())
     else Failure(new Exception(s"javac failed; ${infos.size} messages:\n  ${infos.mkString("\n  ")}"))
@@ -79,9 +83,11 @@ final class TestCase(val baseDir: Directory, val scalaCompiler: ScalaCompiler, v
   def runMain(outLib: Directory): Try[Unit] = {
     val cp = List(outLib, outApp).map(_.jfile) ++ scalaJars
     val cl = new URLClassLoader(cp.map(_.toURI.toURL).toArray, null)
+
     val meth = cl.loadClass("App").getMethod("main", classOf[Array[String]])
 
     val printStream = new PrintStream(new ByteArrayOutputStream(), /* autoflush = */ true, "UTF-8")
+
     val savedOut = System.out
     val savedErr = System.err
     try {

--- a/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/TestCli.scala
+++ b/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/TestCli.scala
@@ -1,3 +1,4 @@
+// scalafmt: { maxColumn = 120, align.preset = some }
 package com.typesafe.tools.mima.lib
 
 import javax.tools._

--- a/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/TestCli.scala
+++ b/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/TestCli.scala
@@ -13,7 +13,7 @@ object TestCli {
   val scala211 = "2.11.12"
   val scala212 = "2.12.21"
   val scala213 = "2.13.18"
-  val scala3   = "3.3.8"
+  val scala3 = "3.3.8"
   val hostScalaVersion = StdLibProps.scalaPropOrNone("maven.version.number").get
   val allScalaVersions = List(scala211, scala212, scala213, scala3)
   val testsDir = Directory("functional-tests/src/test")
@@ -53,11 +53,11 @@ object TestCli {
   final case class Conf(scalaVersions: List[String], dirs: List[Directory])
 
   @tailrec private def readArgs(args: List[String], conf: Conf): Conf = args match {
-    case "-3"   :: xs                  => readArgs(xs, conf.copy(scalaVersions = conf.scalaVersions :+ scala3  ))
+    case "-3" :: xs                    => readArgs(xs, conf.copy(scalaVersions = conf.scalaVersions :+ scala3))
     case "-2.13" :: xs                 => readArgs(xs, conf.copy(scalaVersions = conf.scalaVersions :+ scala213))
     case "-2.12" :: xs                 => readArgs(xs, conf.copy(scalaVersions = conf.scalaVersions :+ scala212))
     case "-2.11" :: xs                 => readArgs(xs, conf.copy(scalaVersions = conf.scalaVersions :+ scala211))
-    case "--scala-version" :: sv :: xs => readArgs(xs, conf.copy(scalaVersions = conf.scalaVersions :+ sv      ))
+    case "--scala-version" :: sv :: xs => readArgs(xs, conf.copy(scalaVersions = conf.scalaVersions :+ sv))
     case "--cross" :: xs               => readArgs(xs, conf.copy(scalaVersions = allScalaVersions))
     case s :: xs                       => readArgs(xs, conf.copy(dirs = testDirs(s) ::: conf.dirs))
     case Nil                           => conf

--- a/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/UnitTests.scala
+++ b/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/UnitTests.scala
@@ -1,3 +1,4 @@
+// scalafmt: { maxColumn = 150 }
 package com.typesafe.tools.mima.lib
 
 import scala.reflect.io.Path

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -12,9 +12,9 @@ object MimaSettings {
   // clear out mimaBinaryIssueFilters when changing this
   val mimaPreviousVersion = "1.1.6"
 
-  val mimaSettings = Def.settings (
-    mimaPreviousArtifacts := Set(pluginProjectID.value.withRevision(mimaPreviousVersion)
-      .withExplicitArtifacts(Vector()) // defaultProjectID uses artifacts.value which breaks it =/
+  val mimaSettings = Def.settings(
+    mimaPreviousArtifacts := Set( // defaultProjectID uses artifacts.value which breaks it =/
+      pluginProjectID.value.withRevision(mimaPreviousVersion).withExplicitArtifacts(Vector())
     ),
     mimaReportSignatureProblems := true,
     mimaBinaryIssueFilters ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,8 +8,8 @@ scalacOptions ++= Seq(
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.2")
 
-addSbtPlugin("com.github.sbt" % "sbt-ci-release"  % "1.12.1")
-addSbtPlugin("com.typesafe"   % "sbt-mima-plugin" % "1.1.6")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.12.1")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.6")
 
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.12")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,8 @@ scalacOptions ++= Seq(
   "-Ywarn-unused:_,-imports",
 )
 
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.2")
+
 addSbtPlugin("com.github.sbt" % "sbt-ci-release"  % "1.12.1")
 addSbtPlugin("com.typesafe"   % "sbt-mima-plugin" % "1.1.6")
 

--- a/sbtplugin/src/main/scala-2.12/PluginCompat.scala
+++ b/sbtplugin/src/main/scala-2.12/PluginCompat.scala
@@ -1,3 +1,4 @@
+// scalafmt: { spaces.afterSymbolicDefs = true }
 package com.typesafe.tools.mima
 package plugin
 
@@ -20,6 +21,7 @@ object PluginCompat {
     def contains(elem: A) = false
     def + (elem: A)       = Set(elem)
     def - (elem: A)       = this
+
     override def size                  = 0
     override def foreach[U](f: A => U) = ()
     override def toSet[B >: A]: Set[B] = this.asInstanceOf[Set[B]]

--- a/sbtplugin/src/main/scala-2.12/PluginCompat.scala
+++ b/sbtplugin/src/main/scala-2.12/PluginCompat.scala
@@ -13,7 +13,7 @@ object PluginCompat {
   }
 
   // Used to differentiate unset mimaPreviousArtifacts from empty mimaPreviousArtifacts
-  private[plugin] object NoPreviousArtifacts extends EmptySet[ModuleID]
+  private[plugin] object NoPreviousArtifacts  extends EmptySet[ModuleID]
   private[plugin] object NoPreviousClassfiles extends EmptyMap[ModuleID, File]
 
   private[plugin] sealed class EmptySet[A] extends Set[A] {

--- a/sbtplugin/src/main/scala-3/PluginCompat.scala
+++ b/sbtplugin/src/main/scala-3/PluginCompat.scala
@@ -1,3 +1,4 @@
+// scalafmt: { maxColumn = 150 }
 package com.typesafe.tools.mima
 package plugin
 

--- a/sbtplugin/src/main/scala-3/PluginCompat.scala
+++ b/sbtplugin/src/main/scala-3/PluginCompat.scala
@@ -10,7 +10,7 @@ object PluginCompat:
     cp.map(_.map(x => conv.toPath(x).toFile))
 
   // Used to differentiate unset mimaPreviousArtifacts from empty mimaPreviousArtifacts
-  private[plugin] object NoPreviousArtifacts extends EmptySet[ModuleID]
+  private[plugin] object NoPreviousArtifacts  extends EmptySet[ModuleID]
   private[plugin] object NoPreviousClassfiles extends EmptyMap[ModuleID, File]
 
   private[plugin] sealed class EmptySet[A] extends Set[A]:
@@ -24,9 +24,9 @@ object PluginCompat:
     override def toSet[B >: A]: Set[B] = this.asInstanceOf[Set[B]]
 
   private[plugin] sealed class EmptyMap[K, V] extends Map[K, V]:
-    def get(key: K)              = None
-    def iterator                 = Iterator.empty
-    def removed(key: K)          = this
+    def get(key: K)     = None
+    def iterator        = Iterator.empty
+    def removed(key: K) = this
 
     override def size                                       = 0
     override def contains(key: K)                           = false

--- a/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/MimaKeys.scala
+++ b/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/MimaKeys.scala
@@ -1,3 +1,4 @@
+// scalafmt: { maxColumn = 240, align.multiline = true }
 package com.typesafe.tools.mima
 package plugin
 
@@ -10,11 +11,9 @@ object MimaKeys extends MimaKeys
 class MimaKeys {
 
   final val mimaPreviousArtifacts       = settingKey[Set[ModuleID]]("Previous released artifacts used to test binary compatibility.")
-
   @transient
   final val mimaReportBinaryIssues      = taskKey[Unit]("Logs all binary incompatibilities to the sbt console/logs.")
   final val mimaExcludeAnnotations      = settingKey[Seq[String]]("The fully-qualified class names of annotations that exclude problems")
-
   @transient
   final val mimaBinaryIssueFilters      = taskKey[Seq[ProblemFilter]]("Filters to apply to binary issues found. Applies both to backward and forward binary compatibility checking.")
   final val mimaFailOnProblem           = settingKey[Boolean]("if true, fail the build on binary incompatibility detection.")
@@ -23,25 +22,18 @@ class MimaKeys {
 
   @transient
   final val mimaDependencyResolution = taskKey[DependencyResolution]("DependencyResolution to use to fetch previous artifacts.")
-
   @transient
   final val mimaPreviousClassfiles   = taskKey[Map[ModuleID, File]]("Directories or jars containing the previous class files used to test compatibility with a given module.")
-
   @transient
   final val mimaCurrentClassfiles    = taskKey[File]("Directory or jar containing the current class files used to test compatibility.")
-
   @transient
   final val mimaCheckDirection       = settingKey[String]("Compatibility checking direction; default is \"backward\", but can also be \"forward\" or \"both\".")
-
   @transient
   final val mimaFindBinaryIssues     = taskKey[Map[ModuleID, (List[Problem], List[Problem])]]("All backward and forward binary incompatibilities between a given module and current project.")
-
   @transient
   final val mimaBackwardIssueFilters = taskKey[Map[String, Seq[ProblemFilter]]]("Filters to apply to binary issues found grouped by version of a module checked against. These filters only apply to backward compatibility checking.")
-
   @transient
   final val mimaForwardIssueFilters  = taskKey[Map[String, Seq[ProblemFilter]]]("Filters to apply to binary issues found grouped by version of a module checked against. These filters only apply to forward compatibility checking.")
-
   @transient
   final val mimaFiltersDirectory     = settingKey[File]("Directory containing issue filters.")
 

--- a/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/MimaPlugin.scala
+++ b/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/MimaPlugin.scala
@@ -1,3 +1,4 @@
+// scalafmt: { maxColumn = 150, align.preset = none }
 package com.typesafe.tools.mima
 package plugin
 
@@ -71,7 +72,7 @@ object MimaPlugin extends AutoPlugin {
     val depRes = mimaDependencyResolution.value
     val taskStreams = streams.value
     val smi = scalaModuleInfo.value
-    previousArtifacts => previousArtifacts match {
+    _ match {
       case _: NoPreviousArtifacts.type => NoPreviousClassfiles
       case previousArtifacts =>
         previousArtifacts.iterator.map { m =>

--- a/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/MimaPlugin.scala
+++ b/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/MimaPlugin.scala
@@ -65,7 +65,7 @@ object MimaPlugin extends AutoPlugin {
 
   trait BinaryIssuesFinder {
     def runMima(prevClassFiles: Map[ModuleID, File], checkDirection: String)
-    : Iterator[(ModuleID, (List[Problem], List[Problem]))]
+        : Iterator[(ModuleID, (List[Problem], List[Problem]))]
   }
 
   val artifactsToClassfiles: Def.Initialize[Task[ArtifactsToClassfiles]] = Def.task {

--- a/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/SbtMima.scala
+++ b/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/SbtMima.scala
@@ -25,10 +25,10 @@ object SbtMima {
     def checkBC = mimaLib.collectProblems(prev, curr, excludeAnnots)
     def checkFC = mimaLib.collectProblems(curr, prev, excludeAnnots)
     dir match {
-       case "backward" | "backwards" => (checkBC, Nil)
-       case "forward" | "forwards"   => (Nil, checkFC)
-       case "both"                   => (checkBC, checkFC)
-       case _                        => (Nil, Nil)
+      case "backward" | "backwards" => (checkBC, Nil)
+      case "forward" | "forwards"   => (Nil, checkFC)
+      case "both"                   => (checkBC, checkFC)
+      case _                        => (Nil, Nil)
     }
   }
 
@@ -135,7 +135,8 @@ object SbtMima {
         } {
           text match {
             case ExclusionPattern(className, target) =>
-              try filters += ProblemFilters.exclude(className, target) catch {
+              try filters += ProblemFilters.exclude(className, target)
+              catch {
                 case NonFatal(t) => failures += s"Error while parsing $file, line $line: ${t.getMessage}"
               }
             case _ => failures += s"Couldn't parse $file, line $line: '$text'"

--- a/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/SbtMima.scala
+++ b/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/SbtMima.scala
@@ -1,3 +1,4 @@
+// scalafmt: { maxColumn = 200, align.preset = some }
 package com.typesafe.tools.mima
 package plugin
 
@@ -34,6 +35,7 @@ object SbtMima {
   private def sanityCheckScalaVersion(scalaVersion: String) = {
     scalaBinaryVersion(scalaVersion) match {
       case "2.11" | "2.12" | "2.13" | "3" => () // ok
+
       case _ => throw new IllegalArgumentException(s"MiMa supports Scala 2.11, 2.12, 2.13 and 3, not $scalaVersion")
     }
   }


### PR DESCRIPTION
- first commit adds scalafmt configuration, sbt plugin and formatting check to CI
- second commit makes a few cosmetic changes and adds formatting overrides
  - this is to bring the end result as close to the original as possible
- third commit applies actual formatting (recommend review with `?w=1`, to ignore whitespace)
- final commit adds the previous two to git-blame ignore file

P.S. This was prompted by the many times Intellij messed up formatting for me while working on #935. Feel free to ignore.