### PR TITLE
Ignore the static field dotty emits per nested object

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/MemberInfo.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/MemberInfo.scala
@@ -31,7 +31,11 @@ sealed abstract class MemberInfo(val owner: ClassInfo, val bytecodeName: String,
 
 private[mima] final class FieldInfo(owner: ClassInfo, bytecodeName: String, flags: Int, descriptor: String)
     extends MemberInfo(owner, bytecodeName, flags, descriptor) {
-  def nonAccessible: Boolean = !isPublic || isSynthetic || hasSyntheticName
+  /** The static field dotty emits per nested object, dropped in 3.10 by scala/scala3#26937.
+   *  Nothing reads it: a nested object is reached as `Foo$Bar$.MODULE$`. */
+  private[mima] def isNestedObjectField: Boolean = // descriptors are dotted, not slashed
+    isStatic && owner.isModuleClass && descriptor == s"L${owner.fullName}$bytecodeName$$;"
+  def nonAccessible: Boolean = !isPublic || isSynthetic || hasSyntheticName || isNestedObjectField
   def fieldString: String    = s"${staticPrefix}field $decodedName in ${owner.classString}"
   override def toString      = s"field $bytecodeName: $descriptor"
 }

--- a/core/src/test/scala/com/typesafe/tools/mima/core/NestedObjectFieldSpec.scala
+++ b/core/src/test/scala/com/typesafe/tools/mima/core/NestedObjectFieldSpec.scala
@@ -1,0 +1,26 @@
+package com.typesafe.tools.mima.core
+
+// Shapes as ClassfileParser stores them, from dotty's output for `package nx; object Foo { object Bar { object Baz } }`.
+final class NestedObjectFieldSpec extends munit.FunSuite {
+  check("the field of a nested object", "Foo$", "Bar", "Lnx.Foo$Bar$;", true)
+  check("the field of an object two deep", "Foo$Bar$", "Baz", "Lnx.Foo$Bar$Baz$;", true)
+  check("MODULE$", "Foo$", "MODULE$", "Lnx.Foo$;", false)
+  check("a field of a nested class, not object", "Foo$", "Bar", "Lnx.Foo$Bar;", false)
+  check("a field named unlike the object it holds", "Foo$", "bar", "Lnx.Foo$Bar$;", false)
+  check("the same shape on a class", "Cls", "Bar", "Lnx.Cls$Bar$;", false)
+  check("the same shape, not static", "Foo$", "Bar", "Lnx.Foo$Bar$;", false, static = false)
+
+  def check(what: String, owner: String, name: String, descriptor: String, expected: Boolean, static: Boolean = true)(
+      implicit loc: munit.Location
+  ): Unit =
+    test(s"mima skips $what: $expected") {
+      assertEquals(field(owner, name, descriptor, static).isNestedObjectField, expected)
+    }
+
+  private def field(owner: String, name: String, descriptor: String, static: Boolean) = {
+    val pkg   = new SyntheticPackageInfo(NoPackageInfo, "nx")
+    val clazz = new SyntheticClassInfo(pkg, owner)
+    val flags = ClassfileConstants.JAVA_ACC_PUBLIC | (if (static) ClassfileConstants.JAVA_ACC_STATIC else 0)
+    new FieldInfo(clazz, name, flags, descriptor)
+  }
+}

--- a/functional-tests/src/test/object-removing-inner-object-nok/problems-3.txt
+++ b/functional-tests/src/test/object-removing-inner-object-nok/problems-3.txt
@@ -1,7 +1,0 @@
-object A#B does not have a correspondent in new version
-object A#B#C does not have a correspondent in new version
-static field B in object A does not have a correspondent in new version
-# in Scala 2 that field problem isn't emitted
-# because the field never existed in the first place
-# put different: Scala 3 adds a static final A$.B field
-# which LGTM as it allows easier access for Java users to nested objects

--- a/functional-tests/src/test/qualified-private-nested-object-changes-ok/app/App.scala
+++ b/functional-tests/src/test/qualified-private-nested-object-changes-ok/app/App.scala
@@ -1,0 +1,5 @@
+object App {
+  def main(args: Array[String]): Unit = {
+    println(foo.Lib.doIt)
+  }
+}

--- a/functional-tests/src/test/qualified-private-nested-object-changes-ok/v1/A.scala
+++ b/functional-tests/src/test/qualified-private-nested-object-changes-ok/v1/A.scala
@@ -1,0 +1,8 @@
+package foo
+
+object Lib {
+  private[foo] object Hidden {
+    def hidden(x: Int) = x
+  }
+  def doIt = Hidden.hidden(1)
+}

--- a/functional-tests/src/test/qualified-private-nested-object-changes-ok/v2/A.scala
+++ b/functional-tests/src/test/qualified-private-nested-object-changes-ok/v2/A.scala
@@ -1,0 +1,8 @@
+package foo
+
+object Lib {
+  private[foo] object Hidden {
+    def hidden(x: Int, y: Int) = x + y
+  }
+  def doIt = Hidden.hidden(1, 0)
+}


### PR DESCRIPTION
Scala 3 emits a public static `Foo$.Bar` of type `Foo$Bar$` that Scala 2 never did and that https://github.com/scala/scala3/pull/25538 drops again in 3.10. Nothing reads it: a nested object is reached as `Foo$Bar$.MODULE$`.

Comparing a 3.9 artifact against a 3.10 one flooded with MissingFieldProblem, 861 of them on scala3-compiler_3, all spurious. The field also let a qualified private nested object escape, so mima checked it on Scala 3 but not on Scala 2.

Fixes https://github.com/scala/scala3/issues/26937
