### PR TITLE
Compare the generic signature of a class

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,23 @@ would not in fact cause problems at run time. Notably, it will warn when
 updating your project to scala 2.12.9+ or 2.13.1+,
 see [this issue](https://github.com/scala-garden/mima/issues/423) for details.
 
-You can opt-in to this check by setting:
+The same setting also enables `IncompatibleClassSignature`, which compares the
+`Signature` of a class rather than of a method. A client compiled against
+
+```scala
+class Base[T](val value: T)
+class Public extends Base[String]("hi")
+```
+
+reads `value` as `Object` and casts it to `String`. Changing the parent to
+`Base[Integer]` leaves every descriptor untouched, so nothing else in MiMa
+notices, and the client gets a `ClassCastException`.
+
+Only the type arguments a class passes to a parent it still has are compared.
+Gaining a parent changes the class signature too, but no client can have been
+compiled against it, so that alone is not reported.
+
+You can opt-in to these checks by setting:
 
 ```scala
 import com.typesafe.tools.mima.plugin.MimaKeys._

--- a/cli/src/main/scala/com/typesafe/tools/mima/cli/ProblemFormatter.scala
+++ b/cli/src/main/scala/com/typesafe/tools/mima/cli/ProblemFormatter.scala
@@ -5,6 +5,7 @@ import com.typesafe.tools.mima.core.DirectMissingMethodProblem
 import com.typesafe.tools.mima.core.FinalMethodProblem
 import com.typesafe.tools.mima.core.InaccessibleFieldProblem
 import com.typesafe.tools.mima.core.InaccessibleMethodProblem
+import com.typesafe.tools.mima.core.IncompatibleClassSignatureProblem
 import com.typesafe.tools.mima.core.IncompatibleFieldTypeProblem
 import com.typesafe.tools.mima.core.IncompatibleMethTypeProblem
 import com.typesafe.tools.mima.core.IncompatibleResultTypeProblem
@@ -58,6 +59,8 @@ case class ProblemFormatter(
 
   // format: off
   def formatProblem(problem: Problem): Option[String] = problem match {
+    case prob: IncompatibleClassSignatureProblem =>
+      if (showBackward && showIncompatibleSignature) Some(str(prob)) else None
     case prob: TemplateProblem if showBackward  => Some(str(prob))
     case _:    TemplateProblem                  => None
 

--- a/core/src/main/scala/com/typesafe/tools/mima/core/Problems.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/Problems.scala
@@ -34,13 +34,14 @@ sealed abstract class Problem extends ProblemRef {
   final def description: String => String = getDescription(_)
 
   private def getDescription(affectedVersion: String): String = this match {
-    case MissingClassProblem(oldclazz)                 => s"${oldclazz.classString} does not have a correspondent in $affectedVersion version"
-    case IncompatibleTemplateDefProblem(ref, newclazz) => s"declaration of ${ref.description} is ${newclazz.description} in $affectedVersion version; changing ${ref.declarationPrefix} to ${newclazz.declarationPrefix} breaks client code"
-    case InaccessibleClassProblem(ref)                 => s"${ref.classString} is inaccessible in $affectedVersion version, it must be public."
-    case AbstractClassProblem(ref)                     => s"${ref.classString} was concrete; is declared abstract in $affectedVersion version"
-    case FinalClassProblem(ref)                        => s"${ref.classString} is declared final in $affectedVersion version"
-    case CyclicTypeReferenceProblem(ref)               => s"the type hierarchy of ${ref.description} is different in $affectedVersion version. Type ${ref.bytecodeName} appears to be a subtype of itself"
-    case MissingTypesProblem(ref, missing)             => s"the type hierarchy of ${ref.description} is different in $affectedVersion version. Missing types ${missing.map(_.fullName).mkString("{", ",", "}")}"
+    case MissingClassProblem(oldclazz)                    => s"${oldclazz.classString} does not have a correspondent in $affectedVersion version"
+    case IncompatibleTemplateDefProblem(ref, newclazz)    => s"declaration of ${ref.description} is ${newclazz.description} in $affectedVersion version; changing ${ref.declarationPrefix} to ${newclazz.declarationPrefix} breaks client code"
+    case InaccessibleClassProblem(ref)                    => s"${ref.classString} is inaccessible in $affectedVersion version, it must be public."
+    case AbstractClassProblem(ref)                        => s"${ref.classString} was concrete; is declared abstract in $affectedVersion version"
+    case FinalClassProblem(ref)                           => s"${ref.classString} is declared final in $affectedVersion version"
+    case CyclicTypeReferenceProblem(ref)                  => s"the type hierarchy of ${ref.description} is different in $affectedVersion version. Type ${ref.bytecodeName} appears to be a subtype of itself"
+    case MissingTypesProblem(ref, missing)                => s"the type hierarchy of ${ref.description} is different in $affectedVersion version. Missing types ${missing.map(_.fullName).mkString("{", ",", "}")}"
+    case IncompatibleClassSignatureProblem(ref, newclazz) => s"${ref.classString} has a different generic signature in $affectedVersion version, where it is ${newclazz.signature} rather than ${ref.signature}. See https://github.com/scala-garden/mima#incompatiblesignatureproblem"
 
     case MissingFieldProblem(ref)                         => s"${ref.memberString} does not have a correspondent in $affectedVersion version"
     case InaccessibleFieldProblem(ref)                    => s"${ref.memberString} is inaccessible in $affectedVersion version, it must be public."
@@ -64,14 +65,15 @@ sealed abstract class Problem extends ProblemRef {
 }
 
 // Template problems
-sealed abstract class TemplateProblem(val ref: ClassInfo)                                 extends Problem with TemplateRef
-final case class MissingClassProblem(oldclazz: ClassInfo)                                 extends TemplateProblem(oldclazz)
-final case class IncompatibleTemplateDefProblem(oldclazz: ClassInfo, newclazz: ClassInfo) extends TemplateProblem(oldclazz)
-final case class InaccessibleClassProblem(newclazz: ClassInfo)                            extends TemplateProblem(newclazz)
-final case class AbstractClassProblem(oldclazz: ClassInfo)                                extends TemplateProblem(oldclazz)
-final case class FinalClassProblem(oldclazz: ClassInfo)                                   extends TemplateProblem(oldclazz)
-final case class CyclicTypeReferenceProblem(clazz: ClassInfo)                             extends TemplateProblem(clazz)
-final case class MissingTypesProblem(newclazz: ClassInfo, missing: Iterable[ClassInfo])   extends TemplateProblem(newclazz)
+sealed abstract class TemplateProblem(val ref: ClassInfo)                                    extends Problem with TemplateRef
+final case class MissingClassProblem(oldclazz: ClassInfo)                                    extends TemplateProblem(oldclazz)
+final case class IncompatibleTemplateDefProblem(oldclazz: ClassInfo, newclazz: ClassInfo)    extends TemplateProblem(oldclazz)
+final case class InaccessibleClassProblem(newclazz: ClassInfo)                               extends TemplateProblem(newclazz)
+final case class AbstractClassProblem(oldclazz: ClassInfo)                                   extends TemplateProblem(oldclazz)
+final case class FinalClassProblem(oldclazz: ClassInfo)                                      extends TemplateProblem(oldclazz)
+final case class CyclicTypeReferenceProblem(clazz: ClassInfo)                                extends TemplateProblem(clazz)
+final case class MissingTypesProblem(newclazz: ClassInfo, missing: Iterable[ClassInfo])      extends TemplateProblem(newclazz)
+final case class IncompatibleClassSignatureProblem(oldclazz: ClassInfo, newclazz: ClassInfo) extends TemplateProblem(oldclazz)
 
 // Member problems
 sealed abstract class MemberProblem(val ref: MemberInfo) extends Problem with MemberRef

--- a/core/src/main/scala/com/typesafe/tools/mima/core/Signature.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/Signature.scala
@@ -11,9 +11,9 @@ class Signature(private val signature: String) {
 
   lazy val canonicalized = {
     signature.headOption match {
-      case None | Some('(') => signature
-
-      case _ =>
+      // only a signature that opens with formal type parameters has any to rename;
+      // a class signature such as `LBase<Ljava/lang/String;>;` has none
+      case Some('<') =>
         val (formalTypeParameters, _) = FormalTypeParameter.parseList(signature.drop(1))
 
         val replacements = formalTypeParameters.map(_.identifier).zipWithIndex
@@ -23,7 +23,33 @@ class Signature(private val signature: String) {
             .replace(s";${from}:", s";__${to}__:")
             .replace(s"T${from};", s"__${to}__")
         }
+
+      case _ => signature
     }
+  }
+
+  /** For a class signature, the type arguments it passes to each parent it names.
+   *
+   *  A client's casts come from the arguments a class passes to a parent it already had,
+   *  so a parent only one version names is absent here rather than counted as a change.
+   */
+  private[mima] def parentTypeArgs: Map[String, String] = {
+    val sig  = canonicalized
+    val rest = if (sig.startsWith("<")) FormalTypeParameter.parseList(sig.drop(1))._2 else sig
+
+    @tailrec def loop(in: String, acc: Map[String, String]): Map[String, String] = {
+      if (in.isEmpty || in.charAt(0) != 'L') acc
+      else {
+        val one          = in.substring(0, endOfClassTypeSig(in))
+        val cut          = one.indexOf('<')
+        val (name, args) =
+          if (cut == -1) (one.substring(1, one.length - 1), "")
+          else (one.substring(1, cut), one.substring(cut, one.length - 1))
+        loop(in.substring(one.length), acc + (name -> args))
+      }
+    }
+
+    loop(rest, Map.empty)
   }
 
   def matches(newer: Signature, isConstructor: Boolean): Boolean = {
@@ -53,6 +79,23 @@ class Signature(private val signature: String) {
 object Signature {
   // javac's Louter<T>.Inner; form yields only the outer; a nested class is reached through innerClasses
   private val classNameRe = "L([^<>;]+)[<;]".r
+
+  /** Where the class type signature starting at `in` ends, past its terminating ';'. */
+  private def endOfClassTypeSig(in: String): Int = {
+    var i     = 0
+    var depth = 0
+    var end   = -1
+    while (end < 0 && i < in.length) {
+      in.charAt(i) match {
+        case '<'               => depth += 1
+        case '>'               => depth -= 1
+        case ';' if depth == 0 => end = i + 1
+        case _                 =>
+      }
+      i += 1
+    }
+    if (end < 0) in.length else end
+  }
 
   def apply(signature: String): Signature = new Signature(signature)
 

--- a/core/src/main/scala/com/typesafe/tools/mima/lib/analyze/template/TemplateChecker.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/lib/analyze/template/TemplateChecker.scala
@@ -22,8 +22,15 @@ private[analyze] object TemplateChecker {
         Some(MissingTypesProblem(newclazz, missingSuperClasses))
       else if (missingInterfaces.nonEmpty)
         Some(MissingTypesProblem(newclazz, missingInterfaces))
+      else if (hasIncompatibleParentTypeArgs(oldclazz, newclazz))
+        Some(IncompatibleClassSignatureProblem(oldclazz, newclazz))
       else
         None
     }
+  }
+
+  private def hasIncompatibleParentTypeArgs(oldclazz: ClassInfo, newclazz: ClassInfo): Boolean = {
+    val newArgs = newclazz.signature.parentTypeArgs
+    oldclazz.signature.parentTypeArgs.exists { case (parent, args) => newArgs.get(parent).exists(_ != args) }
   }
 }

--- a/core/src/test/scala/com/typesafe/tools/mima/core/SignatureSpec.scala
+++ b/core/src/test/scala/com/typesafe/tools/mima/core/SignatureSpec.scala
@@ -31,6 +31,31 @@ final class SignatureSpec extends munit.FunSuite {
     assert(withU.matches(withT, false))
   }
 
+  // signatures as scalac emits them for the class, i.e. formal type parameters then parents
+  test("The class signature parser should split the parents and keep their type arguments") {
+    assertEquals(
+      Signature("Ljava/lang/Object;LDialogSource<Ljava/lang/String;>;").parentTypeArgs,
+      Map("java/lang/Object" -> "", "DialogSource" -> "<Ljava/lang/String;>"),
+    )
+  }
+
+  test("The class signature parser should not confuse a nested type argument for a parent") {
+    assertEquals(
+      Signature("LBase<Lscala/Tuple2<Ljava/lang/String;Ljava/lang/String;>;>;").parentTypeArgs,
+      Map("Base" -> "<Lscala/Tuple2<Ljava/lang/String;Ljava/lang/String;>;>"),
+    )
+  }
+
+  test("The class signature parser should rename formal type parameters, so only the arguments differ") {
+    val withT = Signature("<T:Ljava/lang/Object;>Ljava/lang/Object;LBase<TT;>;")
+    val withA = Signature("<A:Ljava/lang/Object;>Ljava/lang/Object;LBase<TA;>;")
+    assertEquals(withT.parentTypeArgs, withA.parentTypeArgs)
+  }
+
+  test("The class signature parser should yield nothing for a class with no signature") {
+    assertEquals(Signature.none.parentTypeArgs, Map.empty[String, String])
+  }
+
   test("The signature parser should parse a signature with generic bounds that themselves have generics") {
     import Signature.FormalTypeParameter
     val rest = "(TT;Lscala/collection/immutable/List<TU;>;)Lscala/Option<TT;>;>"

--- a/functional-tests/src/test/class-constructor-generics-nok/problems.txt
+++ b/functional-tests/src/test/class-constructor-generics-nok/problems.txt
@@ -1,3 +1,4 @@
+class OptionPane has a different generic signature in new version, where it is <A:Ljava/lang/Object;>Ljava/lang/Object;LDialogSource<TA;>; rather than Ljava/lang/Object;LDialogSource<Ljava/lang/String;>;. See https://github.com/scala-garden/mima#incompatiblesignatureproblem
 method source()scala.Tuple2 in class OptionPane has a different generic signature in new version, where it is ()Lscala/Tuple2<LMyPane<TA;>;Ljava/lang/String;>; rather than ()Lscala/Tuple2<Ljava/lang/String;Ljava/lang/String;>;. See https://github.com/scala-garden/mima#incompatiblesignatureproblem
 method show()java.lang.String in class OptionPane does not have a correspondent in new version
 method this(scala.Tuple2)Unit in class OptionPane has a different generic signature in new version, where it is (Lscala/Tuple2<LMyPane<TA;>;Ljava/lang/String;>;)V rather than (Lscala/Tuple2<Ljava/lang/String;Ljava/lang/String;>;)V. See https://github.com/scala-garden/mima#incompatiblesignatureproblem

--- a/functional-tests/src/test/class-parent-generics-nok/app/App.scala
+++ b/functional-tests/src/test/class-parent-generics-nok/app/App.scala
@@ -1,0 +1,8 @@
+object App {
+  def main(args: Array[String]): Unit = {
+    val s: String = new Public().value
+    println(s)
+    val t: String = new Grows().value
+    println(t)
+  }
+}

--- a/functional-tests/src/test/class-parent-generics-nok/problems.txt
+++ b/functional-tests/src/test/class-parent-generics-nok/problems.txt
@@ -1,0 +1,1 @@
+class Public has a different generic signature in new version, where it is LBase<Ljava/lang/Integer;>; rather than LBase<Ljava/lang/String;>;. See https://github.com/scala-garden/mima#incompatiblesignatureproblem

--- a/functional-tests/src/test/class-parent-generics-nok/v1/A.scala
+++ b/functional-tests/src/test/class-parent-generics-nok/v1/A.scala
@@ -1,0 +1,7 @@
+class Base[T](val value: T)
+
+class Public extends Base[String]("hi")
+
+// adding a parent changes the class signature but breaks nothing
+trait Added
+class Grows extends Base[String]("ok")

--- a/functional-tests/src/test/class-parent-generics-nok/v2/A.scala
+++ b/functional-tests/src/test/class-parent-generics-nok/v2/A.scala
@@ -1,0 +1,6 @@
+class Base[T](val value: T)
+
+class Public extends Base[Integer](Integer.valueOf(1))
+
+trait Added
+class Grows extends Base[String]("ok") with Added

--- a/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/MimaPlugin.scala
+++ b/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/MimaPlugin.scala
@@ -120,8 +120,11 @@ object MimaPlugin extends AutoPlugin {
   }
 
   private val binaryIssueFilters = Def.task {
-    val noSigs = ProblemFilters.exclude[IncompatibleSignatureProblem]("*")
-    mimaBinaryIssueFilters.value ++ (if (mimaReportSignatureProblems.value) Nil else Seq(noSigs))
+    val noSigs = Seq(
+      ProblemFilters.exclude[IncompatibleSignatureProblem]("*"),
+      ProblemFilters.exclude[IncompatibleClassSignatureProblem]("*"),
+    )
+    mimaBinaryIssueFilters.value ++ (if (mimaReportSignatureProblems.value) Nil else noSigs)
   }
 
   // Allows reuse between mimaFindBinaryIssues and mimaReportBinaryIssues


### PR DESCRIPTION
MiMa read a class's Signature attribute for escape detection but never compared it. Changing `class Public extends Base[String]` to `Base[Integer]` leaves every descriptor alone, so nothing was reported, while a client that reads `value` and casts it to String gets a ClassCastException.

Only the type arguments passed to a parent both versions have are compared: gaining a parent changes the signature too, and no client can have compiled against it. Behind mimaReportSignatureProblems, like the method-level check.