### PR TITLE
Load the pickles of an outer chain once

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/ClassInfo.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ClassInfo.scala
@@ -80,7 +80,7 @@ private[mima] sealed abstract class ClassInfo(val owner: PackageInfo) extends In
   final def flags: Int                   = afterLoading(_flags)
   final def signature: Signature         = afterLoading(_signature)
   // the private[foo] mark is only in the pickle, in one of the two classfiles of this class or of an enclosing object
-  final def isScopedPrivate: Boolean     = { outerChain.foreach(c => { c.module.forceLoad; c.moduleClass.forceLoad }); afterLoading(_scopedPrivate) }
+  final def isScopedPrivate: Boolean     = { loadOuterChainModules(); afterLoading(_scopedPrivate) }
   final def isSealed: Boolean            = afterLoading(_sealed)
   final def annotations: List[AnnotInfo] = afterLoading(_annotations)
   final def implClass: ClassInfo         = { owner.setImplClasses; _implClass } // returns NoClass if this is not a trait
@@ -100,6 +100,11 @@ private[mima] sealed abstract class ClassInfo(val owner: PackageInfo) extends In
   final def description: String       = s"$declarationPrefix $formattedFullName"
   final def classString: String       = s"$accessModifier $description".trim
 
+  private var _outerChainModulesLoaded: Boolean = this == NoClass
+  @scala.annotation.tailrec
+  private def loadOuterChainModules(): Unit =
+    if (!_outerChainModulesLoaded) { _outerChainModulesLoaded = true; module.forceLoad; moduleClass.forceLoad; outer.loadOuterChainModules() }
+
   def outerChain: Iterator[ClassInfo] = Iterator.iterate(this)(_.outer).takeWhile(_ != NoClass)
 
   /** Nothing outside this library can extend it. */
@@ -115,7 +120,7 @@ private[mima] sealed abstract class ClassInfo(val owner: PackageInfo) extends In
 
   private[mima] def isDirectlyAccessible: Boolean = isPublic && !isScopedPrivate
 
-  private[mima] def isExternallyAccessible: Boolean = outerChain.forall(_.isDirectlyAccessible)
+  private[mima] lazy val isExternallyAccessible: Boolean = isDirectlyAccessible && (outer == NoClass || outer.isExternallyAccessible)
 
   /** Whether mima checks this class: a client outside the scope can name it, or holds
    *  one all the same because a public method returns it. */


### PR DESCRIPTION
### Problem

`isScopedPrivate` walks the whole outer chain on every call, forcing the pickles of each class it passes, and `isExternallyAccessible` calls it once per class in that chain. The work is quadratic in the nesting depth and repeats for every question about the same class.

### Cause

The walk is needed because a `private[foo]` mark on a nested class lives in the pickle of an enclosing object, so reading it has to load them first. Nothing remembered that it had already done so.

Each class now marks its own chain as loaded, and `isExternallyAccessible` is a `lazy val` in terms of its outer's answer. `NoClass` starts out marked, so the walk ends there, and the mark goes up before the loads, so a pickle that asks the same question during its own parse gets the answer instead of the walk.
