### PR TITLE
Test for package private companion class of an object

### DIFF
--- a/functional-tests/src/test/public-object-with-package-private-companion-nok/app/App.scala
+++ b/functional-tests/src/test/public-object-with-package-private-companion-nok/app/App.scala
@@ -1,0 +1,5 @@
+object App {
+  def main(args: Array[String]): Unit = {
+    println(foo.C.baz(1))
+  }
+}

--- a/functional-tests/src/test/public-object-with-package-private-companion-nok/problems.txt
+++ b/functional-tests/src/test/public-object-with-package-private-companion-nok/problems.txt
@@ -1,0 +1,2 @@
+method baz(Int)Int in object foo.C does not have a correspondent in new version
+static method baz(Int)Int in class foo.C does not have a correspondent in new version

--- a/functional-tests/src/test/public-object-with-package-private-companion-nok/v1/A.scala
+++ b/functional-tests/src/test/public-object-with-package-private-companion-nok/v1/A.scala
@@ -1,0 +1,9 @@
+package foo
+
+private[foo] class C {
+  def bar(x: Int) = x
+}
+
+object C extends C {
+  def baz(x: Int) = x
+}

--- a/functional-tests/src/test/public-object-with-package-private-companion-nok/v2/A.scala
+++ b/functional-tests/src/test/public-object-with-package-private-companion-nok/v2/A.scala
@@ -1,0 +1,7 @@
+package foo
+
+private[foo] class C {
+  def bar(x: Int) = x
+}
+
+object C extends C


### PR DESCRIPTION
Qualifier should not apply to the object
Fixed recently in 050b40710680c842953ef57be5550f32ee7eb2fa. This test is a mirror f the existing
public-class-with-package-private-companion-nok

Covers https://github.com/scala/bug/issues/13181