### PR TITLE
Keep the ';' when renaming type variables in a signature

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/Signature.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/Signature.scala
@@ -21,7 +21,7 @@ class Signature(private val signature: String) {
           sig
             .replace(s"<${from}:", s"<__${to}__:")
             .replace(s";${from}:", s";__${to}__:")
-            .replace(s"T${from};", s"__${to}__")
+            .replace(s"T${from};", s"__${to}__;")
         }
 
       case _ => signature
@@ -104,8 +104,11 @@ object Signature {
   case class FormalTypeParameter(identifier: String, bound: String)
 
   object FormalTypeParameter {
+    // running out of input ends the list, so a signature the grammar below does not
+    // cover yields a partial parse rather than an exception that fails the whole run
     @tailrec def parseList(in: String, acc: List[FormalTypeParameter] = Nil): (List[FormalTypeParameter], String) = {
-      in(0) match {
+      if (in.isEmpty) (acc, in)
+      else in(0) match {
         case '>' => (acc, in.drop(1))
         case _   => {
           val (next, rest) = parseOne(in)
@@ -122,7 +125,9 @@ object Signature {
     }
 
     @tailrec private def splitBoundAndRest(in: String, boundSoFar: String = "", depth: Int = 0): (String, String) = {
-      if (depth > 0) {
+      if (in.isEmpty) {
+        (boundSoFar, in)
+      } else if (depth > 0) {
         in(0) match {
           case '>' => splitBoundAndRest(in.drop(1), boundSoFar + '>', depth - 1)
           case '<' => splitBoundAndRest(in.drop(1), boundSoFar + '<', depth + 1)

--- a/core/src/test/scala/com/typesafe/tools/mima/core/SignatureSpec.scala
+++ b/core/src/test/scala/com/typesafe/tools/mima/core/SignatureSpec.scala
@@ -56,6 +56,34 @@ final class SignatureSpec extends munit.FunSuite {
     assertEquals(Signature.none.parentTypeArgs, Map.empty[String, String])
   }
 
+  // a type parameter bounded by another one, e.g. `class A[T, U <: T]`
+  test("The class signature parser should keep the ';' that terminates a type variable reference") {
+    assertEquals(
+      Signature("<T:Ljava/lang/Object;U:TT;>Ljava/lang/Object;").canonicalized,
+      "<__0__:Ljava/lang/Object;__1__:__0__;>Ljava/lang/Object;",
+    )
+  }
+
+  test("The class signature parser should handle a type parameter bounded by another type parameter") {
+    assertEquals(
+      Signature("<T:Ljava/lang/Object;U:TT;>Ljava/lang/Object;").parentTypeArgs,
+      Map("java/lang/Object" -> ""),
+    )
+    assertEquals(
+      Signature("<Sub:Ljava/lang/Object;Semi:TSub;>Ljava/lang/Object;Lscala/collection/Stepper$EfficientSplit;")
+        .parentTypeArgs,
+      Map("java/lang/Object" -> "", "scala/collection/Stepper$EfficientSplit" -> ""),
+    )
+  }
+
+  test("The signature parser should stop at the end of the input rather than throw") {
+    import Signature.FormalTypeParameter
+    assertEquals(
+      FormalTypeParameter.parseList("T:Ljava/lang/Object;"),
+      (List(FormalTypeParameter("T", "Ljava/lang/Object")), ""))
+    assertEquals(FormalTypeParameter.parseList(""), (List.empty[FormalTypeParameter], ""))
+  }
+
   test("The signature parser should parse a signature with generic bounds that themselves have generics") {
     import Signature.FormalTypeParameter
     val rest = "(TT;Lscala/collection/immutable/List<TU;>;)Lscala/Option<TT;>;>"

--- a/functional-tests/src/test/class-type-param-bounded-by-type-param-ok/app/App.scala
+++ b/functional-tests/src/test/class-type-param-bounded-by-type-param-ok/app/App.scala
@@ -1,0 +1,8 @@
+object App {
+  def main(args: Array[String]): Unit = {
+    val s: String = new Bounded[Any, String]("hi").value
+    println(s)
+    val t: String = new BoundedParent[Any, String]("ok").value
+    println(t)
+  }
+}

--- a/functional-tests/src/test/class-type-param-bounded-by-type-param-ok/v1/A.scala
+++ b/functional-tests/src/test/class-type-param-bounded-by-type-param-ok/v1/A.scala
@@ -1,0 +1,5 @@
+class Base[T](val value: T)
+
+// U's bound is a type variable, so the class signature refers to T as `TT;`
+class Bounded[T, U <: T](val value: U)
+class BoundedParent[T, U <: T](v: U) extends Base[U](v)

--- a/functional-tests/src/test/class-type-param-bounded-by-type-param-ok/v2/A.scala
+++ b/functional-tests/src/test/class-type-param-bounded-by-type-param-ok/v2/A.scala
@@ -1,0 +1,6 @@
+class Base[T](val value: T)
+
+class Bounded[T, U <: T](val value: U) {
+  def other: U = value
+}
+class BoundedParent[T, U <: T](v: U) extends Base[U](v)


### PR DESCRIPTION
A type variable reference is `T<name>;`, so dropping the terminator made a class whose type parameter is bounded by another one, `class A[T, U <: T]`, unparseable and aborted the whole run. Also stop the formal type parameter parser at the end of its input, so a signature its grammar does not cover yields a partial parse instead of an exception.

Fixes #947