### PR TITLE
Ignore the static initializer

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/MemberInfo.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/MemberInfo.scala
@@ -1,7 +1,8 @@
 package com.typesafe.tools.mima.core
 
 object MemberInfo {
-  val ConstructorName = "<init>"
+  val ConstructorName      = "<init>"
+  val ClassInitializerName = "<clinit>"
 }
 
 sealed abstract class MemberInfo(val owner: ClassInfo, val bytecodeName: String, val flags: Int, val descriptor: String)
@@ -74,16 +75,17 @@ private[mima] final class MethodInfo(owner: ClassInfo, bytecodeName: String, fla
   def parametersDesc: String                  = descriptor.substring(1, descriptor.indexOf(")"))
   def matchesType(other: MethodInfo): Boolean = parametersDesc == other.parametersDesc
 
-  private def isDefaultGetter: Boolean   = decodedName.contains("$default$")
-  private def isTraitInit: Boolean       = decodedName == "$init$"
-  private def isExtensionMethod: Boolean = {
+  private def isDefaultGetter: Boolean    = decodedName.contains("$default$")
+  private def isTraitInit: Boolean        = decodedName == "$init$"
+  private def isClassInitializer: Boolean = bytecodeName == MemberInfo.ClassInitializerName
+  private def isExtensionMethod: Boolean  = {
     var i = decodedName.length - 1
     while (i >= 0 && Character.isDigit(decodedName.charAt(i)))
       i -= 1
     decodedName.substring(0, i + 1).endsWith("$extension")
   }
   def nonAccessible: Boolean = {
-    !isPublic || isScopedPrivate || isClassPrivate || isSynthetic ||
+    !isPublic || isScopedPrivate || isClassPrivate || isSynthetic || isClassInitializer ||
     (hasSyntheticName && !(isExtensionMethod || isDefaultGetter || isTraitInit))
   }
   def isScopedPrivate: Boolean = scopedPrivate

--- a/functional-tests/src/test/object-val-becomes-private-lazy-val-ok/app/App.scala
+++ b/functional-tests/src/test/object-val-becomes-private-lazy-val-ok/app/App.scala
@@ -1,0 +1,5 @@
+object App {
+  def main(args: Array[String]): Unit = {
+    println(foo.Lib.it)
+  }
+}

--- a/functional-tests/src/test/object-val-becomes-private-lazy-val-ok/v1/A.scala
+++ b/functional-tests/src/test/object-val-becomes-private-lazy-val-ok/v1/A.scala
@@ -1,0 +1,6 @@
+package foo
+
+object Lib {
+  val it = compute
+  def compute = 42
+}

--- a/functional-tests/src/test/object-val-becomes-private-lazy-val-ok/v2/A.scala
+++ b/functional-tests/src/test/object-val-becomes-private-lazy-val-ok/v2/A.scala
@@ -1,0 +1,7 @@
+package foo
+
+object Lib {
+  private lazy val _it = compute
+  def it = _it
+  def compute = 42
+}


### PR DESCRIPTION
Only the JVM calls `<clinit>`; no client can. Dotty emits it public for an object holding a strict `val` and private for one holding only a `lazy val`, so turning a `val` into a private `lazy val` read as a public method going missing.

Fixes #794