### PR TITLE
Walk the superclass chain nearest first

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/ClassInfo.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ClassInfo.scala
@@ -18,7 +18,7 @@ private[core] object ClassInfo {
 private[core] sealed class SyntheticClassInfo(owner: PackageInfo, val bytecodeName: String) extends ClassInfo(owner) {
   final protected def afterLoading[A](x: => A): A = x
 
-  override lazy val superClasses        = Set(ClassInfo.ObjectClass)
+  override lazy val superClassChain     = List(ClassInfo.ObjectClass)
   final override lazy val allTraits     = Set.empty[ClassInfo]
   final override lazy val allInterfaces = Set.empty[ClassInfo]
 
@@ -26,7 +26,7 @@ private[core] sealed class SyntheticClassInfo(owner: PackageInfo, val bytecodeNa
 }
 
 private[core] object NoClass extends SyntheticClassInfo(NoPackageInfo, "<noclass>") {
-  override lazy val superClasses = Set.empty[ClassInfo]
+  override lazy val superClassChain = Nil
 
   override def canEqual(other: Any) = other.isInstanceOf[NoClass.type]
 }
@@ -137,12 +137,16 @@ private[mima] sealed abstract class ClassInfo(val owner: PackageInfo) extends In
     } else NoClass
   }
 
-  lazy val superClasses: Set[ClassInfo] = {
-    if (this == ClassInfo.ObjectClass) Set.empty
-    else superClass.superClasses + superClass
+  /** Nearest superclass first, so that a lookup walking it finds an override
+   *  before the method it overrides. */
+  lazy val superClassChain: List[ClassInfo] = {
+    if (this == ClassInfo.ObjectClass) Nil
+    else superClass :: superClass.superClassChain
   }
 
-  private def thisAndSuperClasses = Iterator.single(this) ++ superClasses.iterator
+  lazy val superClasses: Set[ClassInfo] = superClassChain.toSet
+
+  private def thisAndSuperClasses = Iterator.single(this) ++ superClassChain.iterator
 
   final def lookupClassFields(field: FieldInfo): Iterator[FieldInfo] =
     thisAndSuperClasses.flatMap(_.fields.get(field.bytecodeName))

--- a/functional-tests/src/test/class-method-moved-to-new-intermediate-class-ok/app/App.scala
+++ b/functional-tests/src/test/class-method-moved-to-new-intermediate-class-ok/app/App.scala
@@ -1,0 +1,1 @@
+object App { def main(args: Array[String]): Unit = println(new C().foo) }

--- a/functional-tests/src/test/class-method-moved-to-new-intermediate-class-ok/v1/A.scala
+++ b/functional-tests/src/test/class-method-moved-to-new-intermediate-class-ok/v1/A.scala
@@ -1,0 +1,2 @@
+abstract class A { def foo: Int }
+class C extends A { def foo: Int = 1 }

--- a/functional-tests/src/test/class-method-moved-to-new-intermediate-class-ok/v2/A.scala
+++ b/functional-tests/src/test/class-method-moved-to-new-intermediate-class-ok/v2/A.scala
@@ -1,0 +1,3 @@
+abstract class A { def foo: Int }
+class B extends A { def foo: Int = 1 }
+class C extends B


### PR DESCRIPTION
Fixes #211.

Pushing an implementation down into a new intermediate class was reported as a break:

```scala
// v1                              // v2
abstract class A { def foo: Int }  abstract class A { def foo: Int }
class C extends A { def foo = 1 }  class B extends A { def foo = 1 }
                                   class C extends B
```
```
abstract method foo()Int in class A does not have a correspondent in new version
```

`C.foo` was matched against `A`'s abstract `foo` rather than `B`'s concrete one, because the
superclass chain was walked furthest ancestor first. It is now walked nearest first.

Reported by akka in 2018 and by cats-effect in typelevel/cats-effect#4424 this year. Both
declined the suggested filter, since it would mask a genuine break later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
