### PR TITLE
Don't report package private trait methods

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/MemberInfo.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/MemberInfo.scala
@@ -12,6 +12,9 @@ sealed abstract class MemberInfo(val owner: ClassInfo, val bytecodeName: String,
   final var scopedPrivate: Boolean = false
   final var classPrivate: Boolean  = false
 
+  /** The class's pickle declares no method of this name, so the compiler generated it. */
+  final var absentFromPickle: Boolean = false
+
   def nonAccessible: Boolean
 
   final def fullName: String          = s"${owner.formattedFullName}.$decodedName"
@@ -84,8 +87,16 @@ private[mima] final class MethodInfo(owner: ClassInfo, bytecodeName: String, fla
       i -= 1
     decodedName.substring(0, i + 1).endsWith("$extension")
   }
+
+  /** A mixin forwarder scalac copies into a class drops the trait method's access:
+   *  the bytecode says public where the source says `private[p]`. */
+  private def isScopedPrivateMixinForwarder: Boolean =
+    absentFromPickle && !owner.isTrait && owner.allTraits.exists {
+      _.methods.get(bytecodeName).exists(m => m.descriptor == descriptor && m.isScopedPrivate)
+    }
   def nonAccessible: Boolean = {
     !isPublic || isScopedPrivate || isClassPrivate || isSynthetic || isClassInitializer ||
+    isScopedPrivateMixinForwarder ||
     (hasSyntheticName && !(isExtensionMethod || isDefaultGetter || isTraitInit))
   }
   def isScopedPrivate: Boolean = scopedPrivate

--- a/core/src/main/scala/com/typesafe/tools/mima/core/MimaUnpickler.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/MimaUnpickler.scala
@@ -186,11 +186,10 @@ object MimaUnpickler {
     }
 
     def doMethods(clazz: ClassInfo, methods: List[SymbolInfo]) = {
-      methods.iterator
-        .filter(!_.isParam)
-        .toSeq.groupBy(_.name).foreach { case (name, pickleMethods) =>
-          doMethodOverloads(clazz, name, pickleMethods)
-        }
+      val byName = methods.iterator.filter(!_.isParam).toSeq.groupBy(_.name)
+      for (m <- clazz.methods.value if !byName.contains(TermName(m.bytecodeName)))
+        m.absentFromPickle = true
+      byName.foreach { case (name, pickleMethods) => doMethodOverloads(clazz, name, pickleMethods) }
     }
 
     def doMethodOverloads(clazz: ClassInfo, name: Name, pickleMethods: Seq[SymbolInfo]) = {

--- a/functional-tests/src/test/class-widens-package-private-trait-method-nok/app/App.scala
+++ b/functional-tests/src/test/class-widens-package-private-trait-method-nok/app/App.scala
@@ -1,0 +1,5 @@
+object App {
+  def main(args: Array[String]): Unit = {
+    println((new foo.D).m)
+  }
+}

--- a/functional-tests/src/test/class-widens-package-private-trait-method-nok/problems.txt
+++ b/functional-tests/src/test/class-widens-package-private-trait-method-nok/problems.txt
@@ -1,0 +1,1 @@
+method m()Int in class foo.D does not have a correspondent in new version

--- a/functional-tests/src/test/class-widens-package-private-trait-method-nok/v1/A.scala
+++ b/functional-tests/src/test/class-widens-package-private-trait-method-nok/v1/A.scala
@@ -1,0 +1,4 @@
+package foo
+
+trait T { private[foo] def m = 1 }
+class D extends T { override def m = 2 }

--- a/functional-tests/src/test/class-widens-package-private-trait-method-nok/v2/A.scala
+++ b/functional-tests/src/test/class-widens-package-private-trait-method-nok/v2/A.scala
@@ -1,0 +1,4 @@
+package foo
+
+trait T { private[foo] def m(x: Int) = x }
+class D extends T { override def m(x: Int) = 2 }

--- a/functional-tests/src/test/package-private-mixin-forwarders-ok/app/App.scala
+++ b/functional-tests/src/test/package-private-mixin-forwarders-ok/app/App.scala
@@ -1,0 +1,5 @@
+object App {
+  def main(args: Array[String]): Unit = {
+    println(new foo.y.C().f)
+  }
+}

--- a/functional-tests/src/test/package-private-mixin-forwarders-ok/v1/A.scala
+++ b/functional-tests/src/test/package-private-mixin-forwarders-ok/v1/A.scala
@@ -1,0 +1,15 @@
+package foo
+
+package x {
+  trait T {
+    def somethingSoThatTHasInitMethod = 0
+    private[foo] def bar(x: Int) = x
+  }
+}
+
+package y {
+  // C does not override bar, so its `bar` is only ever the mixin forwarder
+  class C extends x.T {
+    def f = bar(0)
+  }
+}

--- a/functional-tests/src/test/package-private-mixin-forwarders-ok/v2/A.scala
+++ b/functional-tests/src/test/package-private-mixin-forwarders-ok/v2/A.scala
@@ -1,0 +1,13 @@
+package foo
+
+package x {
+  trait T {
+    def somethingSoThatTHasInitMethod = 0
+  }
+}
+
+package y {
+  class C extends x.T {
+    def f = 0
+  }
+}

--- a/functional-tests/src/test/trait-adds-package-private-abstract-method-nok/app/App.scala
+++ b/functional-tests/src/test/trait-adds-package-private-abstract-method-nok/app/App.scala
@@ -1,0 +1,5 @@
+object App {
+  def main(args: Array[String]): Unit = {
+    println(foo.Lib.call(new bar.X))
+  }
+}

--- a/functional-tests/src/test/trait-adds-package-private-abstract-method-nok/app/X.scala
+++ b/functional-tests/src/test/trait-adds-package-private-abstract-method-nok/app/X.scala
@@ -1,0 +1,3 @@
+package bar
+
+class X extends foo.T { def m = 1 } // outside foo, yet it implements the private[foo] member

--- a/functional-tests/src/test/trait-adds-package-private-abstract-method-nok/problems.txt
+++ b/functional-tests/src/test/trait-adds-package-private-abstract-method-nok/problems.txt
@@ -1,0 +1,1 @@
+private[..] abstract method n()Int in interface foo.T is present only in new version

--- a/functional-tests/src/test/trait-adds-package-private-abstract-method-nok/v1/A.scala
+++ b/functional-tests/src/test/trait-adds-package-private-abstract-method-nok/v1/A.scala
@@ -1,0 +1,4 @@
+package foo
+
+trait T { private[foo] def m: Int }
+object Lib { def call(t: T) = t.m }

--- a/functional-tests/src/test/trait-adds-package-private-abstract-method-nok/v2/A.scala
+++ b/functional-tests/src/test/trait-adds-package-private-abstract-method-nok/v2/A.scala
@@ -1,0 +1,7 @@
+package foo
+
+trait T {
+  private[foo] def m: Int
+  private[foo] def n: Int
+}
+object Lib { def call(t: T) = t.m + t.n }

--- a/functional-tests/src/test/trait-package-private-method-changes-ok/app/App.scala
+++ b/functional-tests/src/test/trait-package-private-method-changes-ok/app/App.scala
@@ -1,0 +1,6 @@
+object App {
+  def main(args: Array[String]): Unit = {
+    println(foo.Lib.doIt)
+    println(foo.Lib.call(new bar.X))
+  }
+}

--- a/functional-tests/src/test/trait-package-private-method-changes-ok/app/X.scala
+++ b/functional-tests/src/test/trait-package-private-method-changes-ok/app/X.scala
@@ -1,0 +1,4 @@
+package bar
+
+// outside foo, yet it may mix the trait in; the default method keeps it working
+class X extends foo.T

--- a/functional-tests/src/test/trait-package-private-method-changes-ok/v1/A.scala
+++ b/functional-tests/src/test/trait-package-private-method-changes-ok/v1/A.scala
@@ -1,0 +1,8 @@
+package foo
+
+trait T { private[foo] def m = 1 }
+class C extends T
+object Lib {
+  def doIt = (new C).m
+  def call(t: T) = t.m
+}

--- a/functional-tests/src/test/trait-package-private-method-changes-ok/v2/A.scala
+++ b/functional-tests/src/test/trait-package-private-method-changes-ok/v2/A.scala
@@ -1,0 +1,8 @@
+package foo
+
+trait T { private[foo] def m(x: Int) = x }
+class C extends T
+object Lib {
+  def doIt = (new C).m(1)
+  def call(t: T) = t.m(1)
+}


### PR DESCRIPTION
Fixes #660.

Scalac copies a `private[p]` trait method into the implementing class as a mixin forwarder,
and that forwarder is public in bytecode:

```scala
package foo
trait T { private[foo] def m = 1 }
class C extends T                          // C.m is a forwarder, not API
class D extends T { override def m = 2 }   // D.m is API, widening the access is legal
```

Changing `T.m` was reported through `C`. Now it isn't, and it still is through `D`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
