### PR TITLE
Resolve the previous artifact for the project's platform

### DIFF
--- a/sbtplugin/src/main/scala-2.12/PluginCompat.scala
+++ b/sbtplugin/src/main/scala-2.12/PluginCompat.scala
@@ -5,6 +5,9 @@ package plugin
 import sbt.*
 
 object PluginCompat {
+  // sbt 1 has no platform setting: the Scala.js and Native plugins put it in `crossVersion`
+  private[plugin] val platformed: Def.Initialize[ModuleID => ModuleID] = Def.setting((m: ModuleID) => m)
+
   def toOldClasspath(cp: Seq[Attributed[File]]): Seq[Attributed[File]] = cp
 
   // This adds `Def.uncached(...)`

--- a/sbtplugin/src/main/scala-3/PluginCompat.scala
+++ b/sbtplugin/src/main/scala-3/PluginCompat.scala
@@ -6,6 +6,17 @@ import sbt.*
 import xsbti.{ FileConverter, HashedVirtualFileRef }
 
 object PluginCompat:
+  /** sbt 2 keeps the platform out of `crossVersion`: on `Platform.sjs1` the artifact is
+   *  named `foo_sjs1_3`. mima names the previous artifact itself, so it has to add that
+   *  suffix before the Scala one, and drop the platform so resolution doesn't add it again. */
+  private[plugin] val platformed: Def.Initialize[ModuleID => ModuleID] = Def.setting {
+    val projectPlatform = Keys.platform.value
+    m =>
+      m.platformOpt.orElse(Some(projectPlatform)).filter(p => p.nonEmpty && p != Platform.jvm) match
+        case Some(p) => m.withName(s"${m.name}_$p").withPlatformOpt(None)
+        case None    => m
+  }
+
   inline def toOldClasspath(cp: Seq[Attributed[HashedVirtualFileRef]])(using conv: FileConverter): Seq[Attributed[File]] =
     cp.map(_.map(x => conv.toPath(x).toFile))
 

--- a/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/MimaPlugin.scala
+++ b/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/MimaPlugin.scala
@@ -72,10 +72,12 @@ object MimaPlugin extends AutoPlugin {
     val depRes = mimaDependencyResolution.value
     val taskStreams = streams.value
     val smi = scalaModuleInfo.value
+    val platformed = PluginCompat.platformed.value
     _ match {
       case _: NoPreviousArtifacts.type => NoPreviousClassfiles
       case previousArtifacts =>
-        previousArtifacts.iterator.map { m =>
+        previousArtifacts.iterator.map { m0 =>
+          val m = platformed(m0)
           val moduleId = CrossVersion(m, smi) match {
             case Some(f) => m.withName(f(m.name)).withCrossVersion(CrossVersion.disabled)
             case None => m

--- a/sbtplugin/src/sbt-test/sbt-mima-plugin/platform-suffix/build.sbt
+++ b/sbtplugin/src/sbt-test/sbt-mima-plugin/platform-suffix/build.sbt
@@ -1,0 +1,3 @@
+scalaVersion := "3.3.6"
+
+Compat.settings

--- a/sbtplugin/src/sbt-test/sbt-mima-plugin/platform-suffix/project/plugins.sbt
+++ b/sbtplugin/src/sbt-test/sbt-mima-plugin/platform-suffix/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % System.getProperty("plugin.version"))

--- a/sbtplugin/src/sbt-test/sbt-mima-plugin/platform-suffix/project/src/main/scala-2.12/Compat.scala
+++ b/sbtplugin/src/sbt-test/sbt-mima-plugin/platform-suffix/project/src/main/scala-2.12/Compat.scala
@@ -1,0 +1,8 @@
+import sbt._, Keys._
+
+object Compat {
+  val checkPreviousArtifact = taskKey[Unit]("the previous artifact resolves for this project's platform")
+
+  // sbt 1 has no platform setting: the Scala.js and Native plugins put the platform in `crossVersion`
+  val settings = Seq(checkPreviousArtifact := ())
+}

--- a/sbtplugin/src/sbt-test/sbt-mima-plugin/platform-suffix/project/src/main/scala-2.12/Compat.scala
+++ b/sbtplugin/src/sbt-test/sbt-mima-plugin/platform-suffix/project/src/main/scala-2.12/Compat.scala
@@ -4,5 +4,5 @@ object Compat {
   val checkPreviousArtifact = taskKey[Unit]("the previous artifact resolves for this project's platform")
 
   // sbt 1 has no platform setting: the Scala.js and Native plugins put the platform in `crossVersion`
-  val settings = Seq(checkPreviousArtifact := ())
+  val settings = Seq(checkPreviousArtifact := {})
 }

--- a/sbtplugin/src/sbt-test/sbt-mima-plugin/platform-suffix/project/src/main/scala-3/Compat.scala
+++ b/sbtplugin/src/sbt-test/sbt-mima-plugin/platform-suffix/project/src/main/scala-3/Compat.scala
@@ -1,0 +1,16 @@
+import sbt.*, Keys.*
+import sbt.librarymanagement.Platform
+import com.typesafe.tools.mima.plugin.MimaPlugin.autoImport.*
+
+object Compat {
+  val checkPreviousArtifact = taskKey[Unit]("the previous artifact resolves for this project's platform")
+
+  val settings = Seq(
+    platform := Platform.sjs1,
+    mimaPreviousArtifacts := Set("org.scala-js" %% "scalajs-dom" % "2.8.0"),
+    checkPreviousArtifact := {
+      val resolved = mimaPreviousClassfiles.value.keys.map(_.name).toList
+      assert(resolved == List("scalajs-dom_sjs1_3"), resolved)
+    },
+  )
+}

--- a/sbtplugin/src/sbt-test/sbt-mima-plugin/platform-suffix/test
+++ b/sbtplugin/src/sbt-test/sbt-mima-plugin/platform-suffix/test
@@ -1,0 +1,2 @@
+# mima has to ask for scalajs-dom_sjs1_3, not scalajs-dom_3
+> checkPreviousArtifact


### PR DESCRIPTION
**Reverted in https://github.com/scala-garden/mima/pull/964, sbt 2.0.7 fixed it on its side**

Fixes #914.

sbt 2 carries the platform in a `platform` setting rather than in the `ModuleID`'s
`crossVersion`, and the plugin never read it. So a Scala.js or Native project compared itself
against the JVM artifact, or failed to resolve one at all. Scala Native worked around it by
hand-mapping `crossVersion`.

The plugin now applies the platform suffix itself, and a scripted test resolves a real
`scalajs-dom_sjs1_3`. No change on sbt 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
