### PR TITLE
Test a package private method on an object

### DIFF
--- a/functional-tests/src/test/object-package-private-method-changes-ok/app/App.scala
+++ b/functional-tests/src/test/object-package-private-method-changes-ok/app/App.scala
@@ -1,0 +1,5 @@
+object App {
+  def main(args: Array[String]): Unit = {
+    println(foo.Lib.doIt)
+  }
+}

--- a/functional-tests/src/test/object-package-private-method-changes-ok/v1/A.scala
+++ b/functional-tests/src/test/object-package-private-method-changes-ok/v1/A.scala
@@ -1,0 +1,4 @@
+package foo
+
+object O { private[foo] def m = 1 }
+object Lib { def doIt = O.m }

--- a/functional-tests/src/test/object-package-private-method-changes-ok/v2/A.scala
+++ b/functional-tests/src/test/object-package-private-method-changes-ok/v2/A.scala
@@ -1,0 +1,4 @@
+package foo
+
+object O { private[foo] def m(x: Int) = x }
+object Lib { def doIt = O.m(1) }


### PR DESCRIPTION
Closes #694.

On Scala 3 the static forwarder dotty emits in the companion class carried none of the
object method's `private[p]`, so mima checked a method no client can call — a filter Scala
2 never needed. It no longer reports, presumably as a side effect of the accessibility
work in #935 and #942.

Test only, no source change. Green on 2.11, 2.12, 2.13 and 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)