### PR TITLE
Test renaming and reordering a method's type parameters

### DIFF
--- a/functional-tests/src/test/method-type-params-renamed-ok/app/App.scala
+++ b/functional-tests/src/test/method-type-params-renamed-ok/app/App.scala
@@ -1,0 +1,5 @@
+object App {
+  def main(args: Array[String]): Unit = {
+    println(new foo.C().m(1, "x"))
+  }
+}

--- a/functional-tests/src/test/method-type-params-renamed-ok/v1/A.scala
+++ b/functional-tests/src/test/method-type-params-renamed-ok/v1/A.scala
@@ -1,0 +1,3 @@
+package foo
+
+class C { def m[A, B](a: A, b: B): A = a }

--- a/functional-tests/src/test/method-type-params-renamed-ok/v2/A.scala
+++ b/functional-tests/src/test/method-type-params-renamed-ok/v2/A.scala
@@ -1,0 +1,3 @@
+package foo
+
+class C { def m[X, Y](a: X, b: Y): X = a }

--- a/functional-tests/src/test/method-type-params-reordered-nok/app/App.scala
+++ b/functional-tests/src/test/method-type-params-reordered-nok/app/App.scala
@@ -1,0 +1,5 @@
+object App {
+  def main(args: Array[String]): Unit = {
+    println(new foo.C().m(1, "x"))
+  }
+}

--- a/functional-tests/src/test/method-type-params-reordered-nok/problems.txt
+++ b/functional-tests/src/test/method-type-params-reordered-nok/problems.txt
@@ -1,0 +1,1 @@
+method m(java.lang.Object,java.lang.Object)java.lang.Object in class foo.C has a different generic signature in new version, where it is <B:Ljava/lang/Object;A:Ljava/lang/Object;>(TA;TB;)TA; rather than <A:Ljava/lang/Object;B:Ljava/lang/Object;>(TA;TB;)TA;. See https://github.com/scala-garden/mima#incompatiblesignatureproblem

--- a/functional-tests/src/test/method-type-params-reordered-nok/testAppRun.pending
+++ b/functional-tests/src/test/method-type-params-reordered-nok/testAppRun.pending
@@ -1,0 +1,1 @@
+# Signature problems aren't runtime errors: reordering only rebinds an explicit `m[Int, String]`

--- a/functional-tests/src/test/method-type-params-reordered-nok/v1/A.scala
+++ b/functional-tests/src/test/method-type-params-reordered-nok/v1/A.scala
@@ -1,0 +1,3 @@
+package foo
+
+class C { def m[A, B](a: A, b: B): A = a }

--- a/functional-tests/src/test/method-type-params-reordered-nok/v2/A.scala
+++ b/functional-tests/src/test/method-type-params-reordered-nok/v2/A.scala
@@ -1,0 +1,3 @@
+package foo
+
+class C { def m[B, A](a: A, b: B): A = a }


### PR DESCRIPTION
Re #363, which asks about two changes that turn out to deserve different answers.

**Renaming** no longer reports — `Signature.canonicalized` numbers the formal type
parameters by declaration order, so `[A, B]` and `[X, Y]` canonicalize alike.

**Reordering** still reports, and should:

```scala
def m[A, B](a: A, b: B): A   →   def m[B, A](a: A, b: B): A
```

The declaration order really did change, and a client that recompiles against an explicit
`m[Int, String]` binds differently. It is not a link error, so the fixture is `-nok` with a
`testAppRun.pending` marker, in the "mima reports, no runtime break" category the sandbox
backlog calls kind 3.

Test only, no source change. Both green on 2.11, 2.12, 2.13 and 3. Leaving the issue open
is up to you — the rename half is settled, the reorder half is arguably working as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)