### PR TITLE
Test moving an implementation up into a default trait method

### DIFF
--- a/functional-tests/src/test/trait-method-implementation-moved-up-forwards-nok/app/App.scala
+++ b/functional-tests/src/test/trait-method-implementation-moved-up-forwards-nok/app/App.scala
@@ -1,0 +1,7 @@
+class D extends foo.I // v2's I.m is concrete, so D gets a mixin forwarder to it
+
+object App {
+  def main(args: Array[String]): Unit = {
+    println(new D().m)
+  }
+}

--- a/functional-tests/src/test/trait-method-implementation-moved-up-forwards-nok/forwards-2.11.txt
+++ b/functional-tests/src/test/trait-method-implementation-moved-up-forwards-nok/forwards-2.11.txt
@@ -1,0 +1,2 @@
+# the old encoding puts the implementation in foo.I$class, which v1 does not have at all
+method m()Int in trait foo.I does not have a correspondent in other version

--- a/functional-tests/src/test/trait-method-implementation-moved-up-forwards-nok/forwards-3.txt
+++ b/functional-tests/src/test/trait-method-implementation-moved-up-forwards-nok/forwards-3.txt
@@ -1,0 +1,2 @@
+# dotty emits no $init$ for a trait with no state
+method m()Int in interface foo.I does not have a correspondent in other version

--- a/functional-tests/src/test/trait-method-implementation-moved-up-forwards-nok/forwards.txt
+++ b/functional-tests/src/test/trait-method-implementation-moved-up-forwards-nok/forwards.txt
@@ -1,0 +1,2 @@
+method m()Int in interface foo.I does not have a correspondent in other version
+synthetic static method $init$(foo.I)Unit in interface foo.I does not have a correspondent in other version

--- a/functional-tests/src/test/trait-method-implementation-moved-up-forwards-nok/v1/A.scala
+++ b/functional-tests/src/test/trait-method-implementation-moved-up-forwards-nok/v1/A.scala
@@ -1,0 +1,4 @@
+package foo
+
+trait I { def m: Int }
+class C extends I { def m = 1 }

--- a/functional-tests/src/test/trait-method-implementation-moved-up-forwards-nok/v2/A.scala
+++ b/functional-tests/src/test/trait-method-implementation-moved-up-forwards-nok/v2/A.scala
@@ -1,0 +1,4 @@
+package foo
+
+trait I { def m: Int = 1 }
+class C extends I

--- a/functional-tests/src/test/trait-method-implementation-moved-up-ok/app/App.scala
+++ b/functional-tests/src/test/trait-method-implementation-moved-up-ok/app/App.scala
@@ -1,0 +1,5 @@
+object App {
+  def main(args: Array[String]): Unit = {
+    println(new foo.C().m)
+  }
+}

--- a/functional-tests/src/test/trait-method-implementation-moved-up-ok/app/App.scala
+++ b/functional-tests/src/test/trait-method-implementation-moved-up-ok/app/App.scala
@@ -1,5 +1,11 @@
+class D extends foo.I { def m = 2 }                    // implements what v1 declares abstract
+class E extends foo.C { override def m = super.m + 1 } // invokespecial on the method that moved
+
 object App {
   def main(args: Array[String]): Unit = {
     println(new foo.C().m)
+    println((new foo.C(): foo.I).m)
+    println(new D().m)
+    println(new E().m)
   }
 }

--- a/functional-tests/src/test/trait-method-implementation-moved-up-ok/v1/A.scala
+++ b/functional-tests/src/test/trait-method-implementation-moved-up-ok/v1/A.scala
@@ -1,0 +1,4 @@
+package foo
+
+trait I { def m: Int }
+class C extends I { def m = 1 }

--- a/functional-tests/src/test/trait-method-implementation-moved-up-ok/v2/A.scala
+++ b/functional-tests/src/test/trait-method-implementation-moved-up-ok/v2/A.scala
@@ -1,0 +1,4 @@
+package foo
+
+trait I { def m: Int = 1 }
+class C extends I


### PR DESCRIPTION
Coverage for the Scala trait encoding, in both directions. Tests only.

```scala
// v1                            // v2
trait I { def m: Int }           trait I { def m: Int = 1 }
class C extends I { def m = 1 }  class C extends I
```

## Backwards — `trait-method-implementation-moved-up-ok`

Compatible. `foo.C.m()I` stays a public, concrete method on all four versions; only its body
changes, from the constant to a forwarder:

```
v1  interface foo.I { public abstract int m(); }
    class foo.C { public int m() { iconst_1; ireturn } }

v2  interface foo.I { public static int m$(foo.I); public default int m(); public static void $init$(foo.I); }
    class foo.C { public int m() { aload_0; invokestatic foo/I.m$:(Lfoo/I;)I; ireturn } }
```

2.11 does the same through the impl class, which v1 does not have at all:

```
v2  class foo.I$class { public static int m(foo.I); public static void $init$(foo.I); }
    class foo.C { public int m() { aload_0; invokestatic foo/I$class.m:(Lfoo/I;)I; ireturn } }
```

So every `invokevirtual foo/C.m()I`, `invokeinterface foo/I.m()I` and `invokespecial
foo/C.m()I` a v1 client emitted still resolves. The app links against the forwarders rather
than taking that on trust:

```scala
class D extends foo.I { def m = 2 }                    // implements what v1 declares abstract
class E extends foo.C { override def m = super.m + 1 } // invokespecial on the method that moved
```

## Forwards — `trait-method-implementation-moved-up-forwards-nok`

A break. A class mixing in the trait, compiled against v2, wires to what only v2 has:

```scala
class D extends foo.I  // v2's I.m is concrete, so D gets a mixin forwarder to it
```

Run against v1:

```
2.11  java.lang.NoClassDefFoundError: foo/I$class            at D.<init>
2.13  java.lang.NoSuchMethodError: 'void foo.I.$init$(foo.I)' at D.<init>
3     java.lang.NoSuchMethodError: 'int foo.I.m$(foo.I)'      at D.m
```

mima reports `foo.I.m` missing on every version, plus `$init$` on 2.12 and 2.13 — dotty emits
none for a stateless trait, and 2.11 names it through the impl class — hence the per-version
oracles.

Green on 2.11, 2.12, 2.13 and 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)