### PR TITLE
Don't let a nested object escape through its accessor

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/MimaUnpickler.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/MimaUnpickler.scala
@@ -226,6 +226,11 @@ object MimaUnpickler {
         if (clsSym.isScopedPrivate) {
           cls._scopedPrivate = true
           if (clsSym.isModuleOrModuleClass && !pickledClasses(cls.module)) cls.module._scopedPrivate = true
+          // the accessor of a nested object is only as accessible as the object; the pickle
+          // has no method symbol for it, so it would otherwise let the object escape
+          if (clsSym.isModuleOrModuleClass)
+            for (m <- cls.outer.methods.value if m.descriptor == s"()L${cls.fullName};")
+              m.scopedPrivate = true
         }
       }
       doMethods(cls, methSyms.filter(_.owner == clsSym).toList)

--- a/functional-tests/src/test/package-private-object-ok/app/App.scala
+++ b/functional-tests/src/test/package-private-object-ok/app/App.scala
@@ -1,0 +1,5 @@
+object App {
+  def main(args: Array[String]): Unit = {
+    println(new foo.C().f)
+  }
+}

--- a/functional-tests/src/test/package-private-object-ok/v1/A.scala
+++ b/functional-tests/src/test/package-private-object-ok/v1/A.scala
@@ -1,0 +1,11 @@
+package foo
+
+class C {
+  private[foo] class K {
+    def f = 1
+  }
+  private[foo] object U {
+    def f = 1
+  }
+  def f = (new K).f + U.f
+}

--- a/functional-tests/src/test/package-private-object-ok/v2/A.scala
+++ b/functional-tests/src/test/package-private-object-ok/v2/A.scala
@@ -1,0 +1,5 @@
+package foo
+
+class C {
+  def f = 2
+}


### PR DESCRIPTION
Fixes #661, with the fixture that issue links.

```scala
// v1                                    // v2
package foo                              package foo

class C {                                class C { def f = 2 }
  private[foo] class K { def f = 1 }
  private[foo] object U { def f = 1 }
  def f = (new K).f + U.f
}
```

On 2.12 and 2.13 the object half was reported, the class half was not:

```
method U()foo.C#U# in class foo.C does not have a correspondent in new version
object foo.C#U does not have a correspondent in new version
```

`private[foo] object U` compiles to a public accessor `C.U()`, which kept none of the
object's access, so the object escaped through it. The accessor is now marked alongside the
object.

Scala 3 was already clean, as was a `private[foo] object` nested in an object. Only one
nested in a class leaked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
