### PR TITLE
Let sbt name the platform of the previous artifact

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -98,7 +98,7 @@ val sbtplugin = project.enablePlugins(SbtPlugin).dependsOn(core.jvm).settings(co
   (pluginCrossBuild / sbtVersion) := {
     scalaBinaryVersion.value match {
       case "2.12" => "1.5.8"
-      case _      => "2.0.0-RC9"
+      case _      => "2.0.7"
     }
   },
   // drop the previous value to drop running Test/compile

--- a/sbtplugin/src/main/scala-2.12/PluginCompat.scala
+++ b/sbtplugin/src/main/scala-2.12/PluginCompat.scala
@@ -5,9 +5,6 @@ package plugin
 import sbt.*
 
 object PluginCompat {
-  // sbt 1 has no platform setting: the Scala.js and Native plugins put it in `crossVersion`
-  private[plugin] val platformed: Def.Initialize[ModuleID => ModuleID] = Def.setting((m: ModuleID) => m)
-
   def toOldClasspath(cp: Seq[Attributed[File]]): Seq[Attributed[File]] = cp
 
   // This adds `Def.uncached(...)`

--- a/sbtplugin/src/main/scala-3/PluginCompat.scala
+++ b/sbtplugin/src/main/scala-3/PluginCompat.scala
@@ -6,17 +6,6 @@ import sbt.*
 import xsbti.{ FileConverter, HashedVirtualFileRef }
 
 object PluginCompat:
-  /** sbt 2 keeps the platform out of `crossVersion`: on `Platform.sjs1` the artifact is
-   *  named `foo_sjs1_3`. mima names the previous artifact itself, so it has to add that
-   *  suffix before the Scala one, and drop the platform so resolution doesn't add it again. */
-  private[plugin] val platformed: Def.Initialize[ModuleID => ModuleID] = Def.setting {
-    val projectPlatform = Keys.platform.value
-    m =>
-      m.platformOpt.orElse(Some(projectPlatform)).filter(p => p.nonEmpty && p != Platform.jvm) match
-        case Some(p) => m.withName(s"${m.name}_$p").withPlatformOpt(None)
-        case None    => m
-  }
-
   inline def toOldClasspath(cp: Seq[Attributed[HashedVirtualFileRef]])(using conv: FileConverter): Seq[Attributed[File]] =
     cp.map(_.map(x => conv.toPath(x).toFile))
 

--- a/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/MimaPlugin.scala
+++ b/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/MimaPlugin.scala
@@ -72,12 +72,10 @@ object MimaPlugin extends AutoPlugin {
     val depRes = mimaDependencyResolution.value
     val taskStreams = streams.value
     val smi = scalaModuleInfo.value
-    val platformed = PluginCompat.platformed.value
     _ match {
       case _: NoPreviousArtifacts.type => NoPreviousClassfiles
       case previousArtifacts =>
-        previousArtifacts.iterator.map { m0 =>
-          val m = platformed(m0)
+        previousArtifacts.iterator.map { m =>
           val moduleId = CrossVersion(m, smi) match {
             case Some(f) => m.withName(f(m.name)).withCrossVersion(CrossVersion.disabled)
             case None => m


### PR DESCRIPTION
The fix for #914 double-suffixes on every released sbt 2 from 2.0.7 on:

```
Error downloading org.scala-js:scalajs-dom_sjs1_sjs1_3:2.8.0
```

sbt 2.0.7 names the platform in `CrossVersion(module, scalaModuleInfo)`, the very call the
plugin makes, so both were adding it. Dropping the plugin's own suffix is the whole fix.

The sbt 2 floor moves to 2.0.7. Nothing is lost: 2.0.0 to 2.0.6 never worked with the
RC-era behaviour the plugin shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
