### PR TITLE
Mark the methods TASTy does not declare

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/TastyUnpickler.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/TastyUnpickler.scala
@@ -124,14 +124,17 @@ object TastyUnpickler {
     }
 
     def doMethods(tmpl: Template) = {
-      val clazz = currentClass
-      (tmpl.fields ::: tmpl.meths).iterator
-        .toSeq.groupBy(_.name).foreach { case (name, pickleMethods) =>
-          doMethodOverloads(clazz, name, pickleMethods)
-          // the class of static forwarders carries no pickle, so mark it from the object's
-          if (clazz.isModuleClass && !pickledClasses(clazz.module))
-            doMethodOverloads(clazz.module, name, pickleMethods)
-        }
+      val clazz    = currentClass
+      val byName   = (tmpl.fields ::: tmpl.meths).iterator.toSeq.groupBy(_.name)
+      val declared = byName.keysIterator.map(_.source).toSet
+      for (m <- clazz.methods.value if !declared(m.bytecodeName))
+        m.absentFromPickle = true
+      byName.foreach { case (name, pickleMethods) =>
+        doMethodOverloads(clazz, name, pickleMethods)
+        // the class of static forwarders carries no pickle, so mark it from the object's
+        if (clazz.isModuleClass && !pickledClasses(clazz.module))
+          doMethodOverloads(clazz.module, name, pickleMethods)
+      }
     }
 
     def doMethodOverloads(clazz: ClassInfo, name: Name, pickleMethods: Seq[TermMemberDef]) = {


### PR DESCRIPTION
#660 came back on Scala 3.9, because dotty stopped marking mixin forwarders as bridges:

```
3.3.8   public int m();  flags: (0x1041) ACC_PUBLIC, ACC_BRIDGE, ACC_SYNTHETIC
3.9.0   public int m();  flags: (0x0001) ACC_PUBLIC
```

So on 3.9 the forwarder of a `private[p]` trait method looks like an ordinary public method
and gets reported again:

```
method m()Int in class foo.C does not have a correspondent in new version
```

MiMa now tells the two apart the same way it does on Scala 2, by asking whether the class
actually declares the method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
