### PR TITLE
Test the fixtures against 3.9 (in addition to 3.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 17]
+        include:
+          - { java: 8 }
+          - { java: 17, sbt2: -Dmima.sbt2 } # the sbt 2 plugin, which needs Scala 3.8
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -31,17 +33,16 @@ jobs:
           java-version: ${{matrix.java}}
           cache: sbt
       - uses: sbt/setup-sbt@v1
-      - run: sbt +test +mimaReportBinaryIssues
-      # use of an old sbt version, as a smoke test. only on 2.12.
-      - run: sbt ++2.12.x 'set sbtplugin/scriptedSbt := "1.5.8"' 'sbtplugin/scripted sbt-mima-plugin/minimal'
-        if: matrix.java == 8
+      - run: sbt ${{matrix.sbt2}} +test +mimaReportBinaryIssues
 
   scripted:
     needs: test
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 17]
+        include:
+          - { java: 8 }
+          - { java: 17, sbt2: -Dmima.sbt2 } # the sbt 2 plugin, which needs Scala 3.8
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -51,21 +52,26 @@ jobs:
           java-version: ${{matrix.java}}
           cache: sbt
       - uses: sbt/setup-sbt@v1
-      - run: sbt +sbtplugin/scripted
+      - run: sbt ${{matrix.sbt2}} +sbtplugin/scripted scriptedOldest
 
   functional-tests:
     needs: test
     strategy:
       fail-fast: false
       matrix:
-        scala: [2.12, 2.13, 3]
+        # the 3.9 compiler needs JDK 17
+        include:
+          - { scala: 2.12, java: 8 }
+          - { scala: 2.13, java: 8 }
+          - { scala: 3.3, java: 8 }
+          - { scala: 3.9, java: 17 }
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 8
+          java-version: ${{matrix.java}}
           cache: sbt
       - uses: sbt/setup-sbt@v1
       - run: sbt ++2.12.x "functional-tests/runMain com.typesafe.tools.mima.lib.UnitTests -${{matrix.scala}}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 17]
+        include:
+          - { java: 8 }
+          - { java: 17, sbt2: -Dmima.sbt2 } # publishes the sbt 2 plugin, and nothing else
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -21,7 +23,7 @@ jobs:
           java-version: ${{matrix.java}}
           cache: sbt
       - uses: sbt/setup-sbt@v1
-      - run: sbt ci-release
+      - run: sbt ${{matrix.sbt2}} ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ After doing that, `reload` if you are in an `sbt` shell session (if that makes n
 
 Tests within the `functional-tests` folder should always pass.
 
-Note: The `problems.txt` is the test oracle. Expected errors are declared using the MiMa's reporting output (i.e., the output of the tool and the expected errors should match perfectly). Admittedly, this coupling is an issue since the testing framework is highly coupled with the tool output used to report errors to the user. We should improve this and make the two independent. Until then, mind that by changing the output of the tool you will likely have to update some of the test oracles (i.e., problems.txt file). If the problems reported are different in Scala 2.12, compared to Scala 2.13, then you may use a `problems-2.12.txt` file.
+Note: The `problems.txt` is the test oracle. Expected errors are declared using the MiMa's reporting output (i.e., the output of the tool and the expected errors should match perfectly). Admittedly, this coupling is an issue since the testing framework is highly coupled with the tool output used to report errors to the user. We should improve this and make the two independent. Until then, mind that by changing the output of the tool you will likely have to update some of the test oracles (i.e., problems.txt file). If the problems reported are different in Scala 2.12, compared to Scala 2.13, then you may use a `problems-2.12.txt` file. Scala 3 oracles may name the minor version, `problems-3.9.txt`, which is preferred over `problems-3.txt`.
 
 The functional tests also include `app` sources (typically an `app/App.scala`) which exercises the library code.
 In more detail, it confirms that if no problems are expected (`problem.txt` is empty, after removing comments)

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,5 @@
 import mimabuild.*
 
-import scala.util.Properties
-
 inThisBuild(Seq(
   organization := "com.typesafe",
   licenses := Seq(License.Apache2),
@@ -23,9 +21,21 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
   scalacOptions ++= compilerOptions(scalaVersion.value),
 )
 
-val isJdk17inCI = Properties.isJavaAtLeast("17") && sys.env.contains("CI") // to split released artifacts by JDK
+// The sbt 2 plugin needs Scala 3.8 and JDK 17; the rest of the build targets Java 8. `-Dmima.sbt2`
+// picks that half, which is how the release splits across two JDKs.
+val sbt2 = sys.props.contains("mima.sbt2")
 
-def skipIfJdk17inCI[T](obj: => Seq[T]): Seq[T] = if (isJdk17inCI) Seq.empty else obj
+def unlessSbt2[T](obj: => Seq[T]): Seq[T] = if (sbt2) Seq.empty else obj
+
+// The plugin is compiled against the oldest sbt it supports, so that it cannot reach for a newer
+// API, and its scripted tests run on the newest, where its users are. `scriptedOldest` runs one of
+// them on the oldest too, so that the support claim stays tested.
+val sbtOldest = if (sbt2) "2.0.7" else "1.5.8"
+val sbtNewest = if (sbt2) "2.0.8" else "1.13.0"
+
+addCommandAlias(
+  "scriptedOldest",
+  s"""set sbtplugin/scriptedSbt := "$sbtOldest"; sbtplugin/scripted sbt-mima-plugin/minimal""")
 
 def compilerOptions(scalaVersion: String): Seq[String] =
   Seq(
@@ -65,7 +75,7 @@ val munit = Def.setting("org.scalameta" %%% "munit" % "1.3.6")
 
 val core = crossProject(JVMPlatform, NativePlatform).crossType(CrossType.Pure).settings(commonSettings).settings(
   name := "mima-core",
-  crossScalaVersions := skipIfJdk17inCI(Seq(scala212, scala213, scala3_3)),
+  crossScalaVersions := unlessSbt2(Seq(scala212, scala213, scala3_3)),
   libraryDependencies += munit.value % Test,
   MimaSettings.mimaSettings,
   apiMappings ++= {
@@ -86,7 +96,7 @@ val cli = crossProject(JVMPlatform)
   .settings(commonSettings)
   .settings(
     name := "mima-cli",
-    crossScalaVersions := skipIfJdk17inCI(Seq(scala212, scala213, scala3_3)),
+    crossScalaVersions := unlessSbt2(Seq(scala212, scala213, scala3_3)),
     libraryDependencies += munit.value % Test,
     mimaFailOnNoPrevious := false,
   )
@@ -94,13 +104,9 @@ val cli = crossProject(JVMPlatform)
 
 val sbtplugin = project.enablePlugins(SbtPlugin).dependsOn(core.jvm).settings(commonSettings).settings(
   name := "sbt-mima-plugin",
-  crossScalaVersions := { if (isJdk17inCI) Seq(scala3_8) else Seq(scala212) },
-  (pluginCrossBuild / sbtVersion) := {
-    scalaBinaryVersion.value match {
-      case "2.12" => "1.5.8"
-      case _      => "2.0.7"
-    }
-  },
+  crossScalaVersions := Seq(if (sbt2) scala3_8 else scala212),
+  (pluginCrossBuild / sbtVersion) := sbtOldest,
+  scriptedSbt := sbtNewest,
   // drop the previous value to drop running Test/compile
   scriptedDependencies := Def.task(()).dependsOn(publishLocal, core.jvm / publishLocal).value,
   scriptedLaunchOpts += s"-Dplugin.version=${version.value}",
@@ -114,7 +120,7 @@ val functionalTests = Project("functional-tests", file("functional-tests"))
   .dependsOn(core.jvm)
   .settings(commonSettings)
   .settings(
-    crossScalaVersions := skipIfJdk17inCI(Seq(scala212, scala213)),
+    crossScalaVersions := unlessSbt2(Seq(scala212, scala213)),
     publish / skip := true,
     libraryDependencies += "io.get-coursier" %% "coursier" % "2.1.24",
     libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
@@ -128,7 +134,7 @@ val integrationTests = Project("integration-tests", file("integration-tests"))
   .dependsOn(functionalTests % "compile->compile")
   .settings(commonSettings)
   .settings(
-    crossScalaVersions := skipIfJdk17inCI(Seq(scala212, scala213)),
+    crossScalaVersions := unlessSbt2(Seq(scala212, scala213)),
     publish / skip := true,
     libraryDependencies += munit.value,
     Test / unmanagedSourceDirectories := Seq((functionalTests / baseDirectory).value / "src" / "it" / "scala"),

--- a/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/TestCase.scala
+++ b/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/TestCase.scala
@@ -120,17 +120,20 @@ final class TestCase(val baseDir: Directory, val scalaCompiler: ScalaCompiler, v
 
   def blankFile(p: Path): Boolean = p.toFile.lines().forall(_.startsWith("#"))
 
+  /** Scala 3 output differs between the LTS and the current release, so an oracle can name the
+   *  minor: `problems-3.9.txt` wins over `problems-3.txt`, which wins over `problems.txt`. */
+  private def scala3Minor = scalaCompiler.version.split('.').take(2).mkString(".")
+
   def versionedFile(path: Path) = {
-    val p    = baseDir.resolve(path).toFile
-    val p212 = (p.parent / (s"${p.stripExtension}-2.12")).addExtension(p.extension).toFile
-    val p213 = (p.parent / (s"${p.stripExtension}-2.13")).addExtension(p.extension).toFile
-    val p3   = (p.parent / (s"${p.stripExtension}-3")).addExtension(p.extension).toFile
-    scalaBinaryVersion match {
-      case "2.12" => if (p212.exists) p212 else p
-      case "2.13" => if (p213.exists) p213 else if (p212.exists) p212 else p
-      case "3"    => if (p3.exists) p3 else p
-      case _      => p
+    val p                   = baseDir.resolve(path).toFile
+    def suffixed(v: String) = (p.parent / s"${p.stripExtension}-$v").addExtension(p.extension).toFile
+    val candidates          = scalaBinaryVersion match {
+      case "2.12" => List("2.12")
+      case "2.13" => List("2.13", "2.12")
+      case "3"    => List(scala3Minor, "3")
+      case _      => Nil
     }
+    candidates.map(suffixed).find(_.exists).getOrElse(p)
   }
 
   def recreateDir(dir: Directory): Unit = {

--- a/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/TestCli.scala
+++ b/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/TestCli.scala
@@ -12,9 +12,10 @@ object TestCli {
   // Keep in sync with build.sbt
   val scala212 = "2.12.21"
   val scala213 = "2.13.18"
-  val scala3 = "3.3.8"
+  val scala3_3 = "3.3.8" // keep at LTS
+  val scala3_9 = "3.9.0"
   val hostScalaVersion = StdLibProps.scalaPropOrNone("maven.version.number").get
-  val allScalaVersions = List(scala212, scala213, scala3)
+  val allScalaVersions = List(scala212, scala213, scala3_3, scala3_9)
   val testsDir = Directory("functional-tests/src/test")
 
   def argsToTests(args: List[String], runTestCase: TestCase => Try[Unit]): Tests =
@@ -52,7 +53,9 @@ object TestCli {
   final case class Conf(scalaVersions: List[String], dirs: List[Directory])
 
   @tailrec private def readArgs(args: List[String], conf: Conf): Conf = args match {
-    case "-3" :: xs                    => readArgs(xs, conf.copy(scalaVersions = conf.scalaVersions :+ scala3))
+    case "-3.9" :: xs                  => readArgs(xs, conf.copy(scalaVersions = conf.scalaVersions :+ scala3_9))
+    case "-3.3" :: xs                  => readArgs(xs, conf.copy(scalaVersions = conf.scalaVersions :+ scala3_3))
+    case "-3" :: xs                    => readArgs(xs, conf.copy(scalaVersions = conf.scalaVersions :+ scala3_3))
     case "-2.13" :: xs                 => readArgs(xs, conf.copy(scalaVersions = conf.scalaVersions :+ scala213))
     case "-2.12" :: xs                 => readArgs(xs, conf.copy(scalaVersions = conf.scalaVersions :+ scala212))
     case "--scala-version" :: sv :: xs => readArgs(xs, conf.copy(scalaVersions = conf.scalaVersions :+ sv))

--- a/functional-tests/src/test/class-method-abstract-override-of-concrete-supertrait-method-nok/problems-3.9.txt
+++ b/functional-tests/src/test/class-method-abstract-override-of-concrete-supertrait-method-nok/problems-3.9.txt
@@ -1,0 +1,3 @@
+# 3.9 reports what problems-3.txt says is missing on Scala 3, so it matches Scala 2 again
+abstract method foo()Int in class B does not have a correspondent in new version
+in new version there is abstract method foo()Int in class B, which does not have a correspondent

--- a/functional-tests/src/test/class-method-abstract-override-of-concrete-supertrait-method-nok/problems-3.txt
+++ b/functional-tests/src/test/class-method-abstract-override-of-concrete-supertrait-method-nok/problems-3.txt
@@ -1,6 +1,5 @@
 in new version there is abstract method foo()Int in class B, which does not have a correspondent
-# what's missing is:
-#     abstract method foo()Int in class B does not have a correspondent in new version
-# which is a `DirectAbstractMethodProblem`, rather than the above `ReversedAbstractMethodProblem`
-# not sure exactly what that means... ¯\_(ツ)_/¯
-# https://github.com/scala-garden/mima/issues/590
+# The DirectAbstractMethodProblem that Scala 2 also reports is missing here because up to 3.3
+# dotty flags B's mixin forwarder ACC_BRIDGE | ACC_SYNTHETIC, and of the two checks only
+# checkExisting1 filters synthetic methods, so it never compares v1's concrete foo against v2's
+# abstract one. 3.9 stopped flagging the forwarder: see problems-3.9.txt.

--- a/functional-tests/src/test/sealed-trait-loses-method-nok/problems-3.9.txt
+++ b/functional-tests/src/test/sealed-trait-loses-method-nok/problems-3.9.txt
@@ -1,0 +1,2 @@
+method gone()Int in interface foo.T does not have a correspondent in new version
+method gone()Int in class foo.C does not have a correspondent in new version


### PR DESCRIPTION
Dotty stopped flagging mixin forwarders as bridges:

```
3.3.8   B.foo  flags: ACC_PUBLIC, ACC_BRIDGE, ACC_SYNTHETIC
3.9.0   B.foo  flags: ACC_PUBLIC
```

`nonAccessible` filters `isSynthetic`, so on 3.9 mima checks forwarders it used to skip and reports
two more problems — both correct, both what Scala 2 has always reported. 3.3 and 3.9 legitimately
differ, so an oracle can name the minor: `problems-3.9.txt` over `problems-3.txt` over
`problems.txt`. (Of the four differences, the two that *are* false positives are #965.)

The 3.9 compiler is class file 61, so its leg needs JDK 17 — which `isJdk17inCI` broke, having
emptied every other project's `crossScalaVersions`:

```
[error] Switch failed: no subprojects have a version matching "2.12.x" in the crossScalaVersions setting.
```

The job now states which half to cross build rather than the build guessing from the JDK.

Both sbt majors are also treated alike:

```scala
val sbtOldest = if (sbt2) "2.0.7" else "1.5.8"   // compiled against, so no newer API creeps in
val sbtNewest = if (sbt2) "2.0.8" else "1.13.0"  // and where the scripted tests run
```

with `scriptedOldest` keeping one test on the oldest. Both used to be the floor, which is how #964
slipped through — 2.0.7 changed `CrossVersion(module, scalaModuleInfo)` and CI only ran the pin. The
old smoke test pinned that same floor, so it goes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
