### PR TITLE
Let a default method stand in for a dropped override

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/ClassInfo.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ClassInfo.scala
@@ -165,6 +165,12 @@ private[mima] sealed abstract class ClassInfo(val owner: PackageInfo) extends In
   final def lookupMethods(method: MethodInfo): Iterator[MethodInfo] =
     lookupClassMethods(method) ++ lookupInterfaceMethods(method)
 
+  /** The default methods a class inherits: since Java 8 an invokevirtual resolves through the
+   *  superinterfaces, so these stand in for a method the class does not declare itself. */
+  final def lookupConcreteInterfaceMethods(method: MethodInfo): Iterator[MethodInfo] =
+    if (method.isStatic) Iterator.empty // static interface methods are not inherited
+    else allInterfaces.iterator.flatMap(_.concreteMethods).filter(_.bytecodeName == method.bytecodeName)
+
   final def lookupConcreteTraitMethods(method: MethodInfo): Iterator[MethodInfo] =
     allTraits.iterator.flatMap(_.concreteMethods).filter(_.bytecodeName == method.bytecodeName)
 

--- a/core/src/main/scala/com/typesafe/tools/mima/lib/analyze/method/MethodChecker.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/lib/analyze/method/MethodChecker.scala
@@ -29,7 +29,7 @@ private[analyze] object MethodChecker {
       if (oldmeth.isDeferred)
         checkExisting1Impl(oldmeth, newclazz, _.lookupMethods(oldmeth))
       else
-        checkExisting1Impl(oldmeth, newclazz, _.lookupClassMethods(oldmeth))
+        checkExisting1Impl(oldmeth, newclazz, c => c.lookupClassMethods(oldmeth) ++ c.lookupConcreteInterfaceMethods(oldmeth))
     } else {
       if (oldmeth.owner.hasStaticImpl(oldmeth))
         checkStaticImplMethod(oldmeth, newclazz)

--- a/functional-tests/src/test/class-drops-override-of-default-method-ok/app/App.scala
+++ b/functional-tests/src/test/class-drops-override-of-default-method-ok/app/App.scala
@@ -1,0 +1,6 @@
+object App {
+  def main(args: Array[String]): Unit = {
+    println(new foo.C().m)
+    println((new foo.C(): foo.E).m)
+  }
+}

--- a/functional-tests/src/test/class-drops-override-of-default-method-ok/v1/C.java
+++ b/functional-tests/src/test/class-drops-override-of-default-method-ok/v1/C.java
@@ -1,0 +1,2 @@
+package foo;
+public class C implements E { public int m() { return 1; } } // a redundant override

--- a/functional-tests/src/test/class-drops-override-of-default-method-ok/v1/E.java
+++ b/functional-tests/src/test/class-drops-override-of-default-method-ok/v1/E.java
@@ -1,0 +1,2 @@
+package foo;
+public interface E { default int m() { return 1; } }

--- a/functional-tests/src/test/class-drops-override-of-default-method-ok/v2/C.java
+++ b/functional-tests/src/test/class-drops-override-of-default-method-ok/v2/C.java
@@ -1,0 +1,2 @@
+package foo;
+public class C implements E { } // dropped; E.m covers it

--- a/functional-tests/src/test/class-drops-override-of-default-method-ok/v2/E.java
+++ b/functional-tests/src/test/class-drops-override-of-default-method-ok/v2/E.java
@@ -1,0 +1,2 @@
+package foo;
+public interface E { default int m() { return 1; } }


### PR DESCRIPTION
Since Java 8 a class can inherit a concrete method from an interface, but `checkExisting1` resolved a concrete method with `lookupClassMethods`, which walks only the class chain:

```java
interface E { default int m() { return 1; } }

// v1
class C implements E { public int m() { return 1; } }
// v2
class C implements E { }
```

`C.m` was reported as `DirectMissingMethod`, though `new C().m()` still resolves through `E`. The lookup now continues into the superinterfaces, after the class chain, as in JVMS §5.4.6.

One known consequence: where the interface method's signature still carries a type variable (`class C implements E<String>` inheriting `E<T>.m(): List<T>`), the comparison reports `IncompatibleSignatureProblem` without substituting `T`. It is hidden by default, and the deferred path — which already resolved through interfaces — has always done this. Substituting via `Signature.parentTypeArgs` is a separate fix.

Fixes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)
