### PR TITLE
Read a TASTy reference to a symbol of the same unit

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/TastyUnpickler.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/TastyUnpickler.scala
@@ -161,7 +161,13 @@ object TastyUnpickler {
     def readTypeRef()      = TypeRef(name = readName(), qual = readType())          // NameRef qual_Type               -- A reference `qual.name` to a non-local member
     def readTermRef()      = TermRef(name = readName(), qual = readType())          // possiblySigned_NameRef qual_Type -- A reference `qual.name` to a non-local term, e.g. the object a class sits in
     def readAnnot()        = { readEnd(); Annot(readType(), skipTree(readByte())) } // tycon_Type fullAnnotation_Tree  -- An annotation, given (class) type of constructor, and full application tree
-    def readSharedType()   = unpickleTree(forkAt(readAddr()), names) match {
+    // {TYPE,TERM}REFsymbol sym_ASTRef qual_Type -- a reference to a symbol of this unit. The
+    // name is not in the payload, it sits at the definition the ASTRef points to.
+    def nameAt(addr: Addr)  = { val d = forkAt(addr); d.readByte(); d.readEnd(); names(d.readNat()) }
+    def readTypeRefSymbol() = TypeRef(name = nameAt(readAddr()), qual = readType())
+    def readTermRefSymbol() = TermRef(name = nameAt(readAddr()), qual = readType())
+
+    def readSharedType() = unpickleTree(forkAt(readAddr()), names) match {
       case tpe: Type => tpe
       // this reader skips some trees, and an alias can share one of those
       case _ => UnknownType(SHAREDtype)
@@ -188,7 +194,11 @@ object TastyUnpickler {
       case TERMREF    => readTermRef()
       case SELECT     => readTermRef() // SELECT carries the same name and qualifier
       case SHAREDtype => readSharedType()
-      case tag        => skipTree(tag); UnknownType(tag)
+
+      case TYPEREFsymbol => readTypeRefSymbol()
+      case TERMREFsymbol => readTermRefSymbol()
+      case THIS          => readType() // THIS clsRef_Type -- the class it names
+      case tag           => skipTree(tag); UnknownType(tag)
     }
 
     // APPLIEDtype/APPLIEDtpt Length tycon arg* -- tycon[args]
@@ -348,7 +358,8 @@ object TastyUnpickler {
           }
         case AstCat3AST    => readTree()
         case AstCat4NatAST => tag match {
-            case TYPEREFsymbol => skipTree(tag) match { case UnknownTree(tag) => UnknownType(tag) }
+            case TYPEREFsymbol => readTypeRefSymbol()
+            case TERMREFsymbol => readTermRefSymbol()
             case TYPEREF       => readTypeRef()
             case _             => skipTree(tag)
           }

--- a/functional-tests/src/test/qualified-private-class-escaping-through-alias-in-its-own-object-nok/app/App.scala
+++ b/functional-tests/src/test/qualified-private-class-escaping-through-alias-in-its-own-object-nok/app/App.scala
@@ -1,0 +1,3 @@
+object App {
+  def main(args: Array[String]): Unit = println(new foo.Holder.K().bar(1))
+}

--- a/functional-tests/src/test/qualified-private-class-escaping-through-alias-in-its-own-object-nok/problems.txt
+++ b/functional-tests/src/test/qualified-private-class-escaping-through-alias-in-its-own-object-nok/problems.txt
@@ -1,0 +1,1 @@
+method bar(Int)Int in class foo.Holder#Inner does not have a correspondent in new version

--- a/functional-tests/src/test/qualified-private-class-escaping-through-alias-in-its-own-object-nok/v1/A.scala
+++ b/functional-tests/src/test/qualified-private-class-escaping-through-alias-in-its-own-object-nok/v1/A.scala
@@ -1,0 +1,8 @@
+package foo
+
+object Holder {
+  private[foo] class Inner { def bar(x: Int) = x }
+  // the alias and the class it names share an owner, so the pickle refers to
+  // Inner through `this`
+  type K = Inner
+}

--- a/functional-tests/src/test/qualified-private-class-escaping-through-alias-in-its-own-object-nok/v2/A.scala
+++ b/functional-tests/src/test/qualified-private-class-escaping-through-alias-in-its-own-object-nok/v2/A.scala
@@ -1,0 +1,8 @@
+package foo
+
+object Holder {
+  private[foo] class Inner { def bar(x: Int, y: Int) = x + y }
+  // the alias and the class it names share an owner, so the pickle refers to
+  // Inner through `this`
+  type K = Inner
+}


### PR DESCRIPTION
Fixes #969.

```scala
package foo
object Holder {
  private[foo] class Inner { def bar(x: Int) = x }
  type K = Inner
}
```

A client writes `new foo.Holder.K().bar(1)`. Give `bar` a second parameter and under Scala 3
MiMa reported nothing, so the client broke with a `NoSuchMethodError`. Scala 2 already
reported it.

TASTy names a class defined in the same object by the address of its definition rather than
by name, and the reader skipped that, so the alias resolved to nothing. This also covers
`type L <: Inner` in the same position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
