### PR TITLE
Update mima to 1.2.0

### DIFF
--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -10,7 +10,7 @@ import com.typesafe.tools.mima.plugin.MimaPlugin.autoImport._
 
 object MimaSettings {
   // clear out mimaBinaryIssueFilters when changing this
-  val mimaPreviousVersion = "1.1.6"
+  val mimaPreviousVersion = "1.2.0"
 
   val mimaSettings = Def.settings(
     mimaPreviousArtifacts := Set( // defaultProjectID uses artifacts.value which breaks it =/

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ scalacOptions ++= Seq(
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.2")
 
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.12.1")
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.6")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.2.0")
 
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.4.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.12")


### PR DESCRIPTION
Post-release bump. `sbt-mima-plugin_sbt2_3` did not exist at 1.1.6, so this is the first
release the sbt 2 plugin gets checked against a previous version.

`+mimaReportBinaryIssues` is green on both legs, and the existing filters are no longer
needed for it — left in place because they say the unpicklers are not API, not because of
1.1.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
